### PR TITLE
Make quad meshes great again

### DIFF
--- a/Models/LayerModel.cs
+++ b/Models/LayerModel.cs
@@ -95,6 +95,12 @@ namespace ProjectionMapper.Models
         public int TargetMonitorIndex { get; set; } = -1;
 
         /// <summary>
+        /// Whether to show the mesh overlay (quad outline and meshpoints) for this layer on the output.
+        /// This is a UI preference stored per-layer and defaults to true.
+        /// </summary>
+        public bool ShowOverlay { get; set; } = true;
+
+        /// <summary>
         /// When true, the layer's audio should be played alongside decoded video frames (if supported).
         /// This is a user preference stored on the model so services can resume/pause playback appropriately.
         /// </summary>

--- a/Rendering/RenderLoop.cs
+++ b/Rendering/RenderLoop.cs
@@ -37,36 +37,41 @@ namespace ProjectionMapper.Rendering
 
             _loopTask = Task.Run(async () =>
             {
-                var sw = new Stopwatch();
-                var minFrameTimeMs = _targetFps.HasValue && _targetFps > 0 ? 1000.0 / _targetFps.Value : 0.0;
-
-                while (!_cts.IsCancellationRequested)
+                try
                 {
-                    sw.Restart();
-                    try
-                    {
-                        await _renderCallback(_cts.Token).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) { break; }
-                    catch (Exception)
-                    {
-                        // Renderer exceptions should be caught/logged at the renderCallback level; swallow here to keep the loop alive.
-                    }
+                    var sw = new Stopwatch();
+                    var minFrameTimeMs = _targetFps.HasValue && _targetFps > 0 ? 1000.0 / _targetFps.Value : 0.0;
 
-                    if (minFrameTimeMs > 0)
+                    while (!_cts.IsCancellationRequested)
                     {
-                        var elapsed = sw.Elapsed.TotalMilliseconds;
-                        var delay = minFrameTimeMs - elapsed;
-                        if (delay > 1)
+                        sw.Restart();
+                        try
                         {
-                            try
+                            await _renderCallback(_cts.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) { break; }
+                        catch (Exception)
+                        {
+                            // Renderer exceptions should be caught/logged at the renderCallback level; swallow here to keep the loop alive.
+                        }
+
+                        if (minFrameTimeMs > 0)
+                        {
+                            var elapsed = sw.Elapsed.TotalMilliseconds;
+                            var delay = minFrameTimeMs - elapsed;
+                            if (delay > 1)
                             {
-                                await Task.Delay(TimeSpan.FromMilliseconds(delay), _cts.Token).ConfigureAwait(false);
+                                try
+                                {
+                                    await Task.Delay(TimeSpan.FromMilliseconds(delay), _cts.Token).ConfigureAwait(false);
+                                }
+                                catch (OperationCanceledException) { break; }
                             }
-                            catch (OperationCanceledException) { break; }
                         }
                     }
                 }
+                catch (ObjectDisposedException) { }
+                catch (Exception) { }
             }, _cts.Token);
         }
 

--- a/Rendering/RendererManager.cs
+++ b/Rendering/RendererManager.cs
@@ -30,7 +30,13 @@ namespace ProjectionMapper.Rendering
         {
             _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
             _renderer.FrameReady += OnFrameReady;
+            ShowMeshOverlay = true; // enabled by default
         }
+
+        /// <summary>
+        /// When true, mesh overlay (quad outline and points) will be shown on output hosts when provided.
+        /// </summary>
+        public bool ShowMeshOverlay { get; set; }
 
         /// <summary>
         /// Map normalized output coordinates (0..1) to renderer pixel coordinates using the attached host's current frame
@@ -154,89 +160,74 @@ namespace ProjectionMapper.Rendering
             {
                 foreach (var win in _fullscreenWindows.Values.ToList())
                 {
-                    try { InvokeOnUi(() => win?.HostControl?.Clear()); } catch (Exception ex) { Debug.WriteLine($"OnFrameReady clear fullscreen failed: {ex}"); }
+                    try { InvokeOnUi(() => win?.HostControl?.Clear()); } catch { }
                 }
             }
             else
             {
                 foreach (var win in _fullscreenWindows.Values.ToList())
                 {
-                try
-                {
-                    // All accesses to Window/Control properties must be done on UI thread.
-                    InvokeOnUi(() =>
+                    try
                     {
-                        try
+                        InvokeOnUi(() =>
                         {
-                            if (win == null)
-                            {
-                                Debug.WriteLine("OnFrameReady: encountered null fullscreen window in collection (UI thread)");
-                                return;
-                            }
-                            if (win.HostControl == null)
-                            {
-                                Debug.WriteLine("OnFrameReady: fullscreen window has null HostControl (UI thread)");
-                                return;
-                            }
-                            try
-                            {
-                                Debug.WriteLine($"OnFrameReady: preparing to mirror frame to fullscreen host for window '{win.Title}' (UI thread). Visible={win.IsVisible}, State={win.WindowState}");
-                                if (!win.IsVisible || win.WindowState == WindowState.Minimized)
-                                {
-                                    Debug.WriteLine($"OnFrameReady: skipping SetFrame because window not visible or minimized for monitor host '{win.Title}'");
-                                    return;
-                                }
-
-                                try
-                                {
-                                    win.HostControl.SetFrame(bmp);
-
-                                    // Log diagnostic about the host control's current frame
-                                    try
-                                    {
-                                        var cf = win.HostControl.CurrentFrame;
-                                        if (cf != null)
-                                        {
-                                            Debug.WriteLine($"OnFrameReady: SetFrame succeeded; HostControl.CurrentFrame size={cf.PixelWidth}x{cf.PixelHeight}");
-                                        }
-                                        else
-                                        {
-                                            Debug.WriteLine($"OnFrameReady: SetFrame completed but HostControl.CurrentFrame is null");
-                                        }
-                                    }
-                                    catch (Exception exInner2)
-                                    {
-                                        Debug.WriteLine($"OnFrameReady: failed to read HostControl.CurrentFrame (UI thread): {exInner2}");
-                                    }
-
-                                    try
-                                    {
-                                        Debug.WriteLine($"OnFrameReady: fullscreen window bounds L,T,W,H = {win.Left},{win.Top},{win.Width},{win.Height}");
-                                    }
-                                    catch { }
-                                }
-                                catch (Exception ex)
-                                {
-                                    Debug.WriteLine($"OnFrameReady set fullscreen failed (UI thread): {ex}");
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Debug.WriteLine($"OnFrameReady inner UI action failed: {ex}");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.WriteLine($"OnFrameReady inner UI action failed: {ex}");
-                        }
-                    });
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"OnFrameReady: exception while scheduling mirror to fullscreen window: {ex}");
-                }
+                            if (win == null || win.HostControl == null) return;
+                            if (!win.IsVisible || win.WindowState == WindowState.Minimized) return;
+                            try { win.HostControl.SetFrame(bmp); } catch { }
+                        });
+                    }
+                    catch { }
                 }
             }
+        }
+
+        /// <summary>
+        /// Set mesh overlay (quad outline and optional points) on either the main attached host or a fullscreen host for a monitor.
+        /// If monitorIndex is null, the main attached host will be used. If quadPoints is null the overlay will be cleared.
+        /// </summary>
+        public void SetMeshOverlayForMonitor(int? monitorIndex, Point[]? quadPoints, bool showPoints)
+        {
+            if (!ShowMeshOverlay)
+            {
+                // If overlays disabled globally, ensure cleared
+                ClearAllOverlays();
+                return;
+            }
+
+            try
+            {
+                if (monitorIndex.HasValue)
+                {
+                    if (_fullscreenWindows.TryGetValue(monitorIndex.Value, out var win) && win != null)
+                    {
+                        InvokeOnUi(() => win.HostControl.SetMeshOverlay(quadPoints, showPoints));
+                        return;
+                    }
+                }
+
+                // fallback to main host
+                if (_host != null)
+                {
+                    InvokeOnUi(() => _host.SetMeshOverlay(quadPoints, showPoints));
+                }
+            }
+            catch (Exception ex) { Debug.WriteLine($"SetMeshOverlayForMonitor failed: {ex}"); }
+        }
+
+        /// <summary>
+        /// Clear overlays on all hosts (main and fullscreen).
+        /// </summary>
+        public void ClearAllOverlays()
+        {
+            try
+            {
+                if (_host != null) InvokeOnUi(() => _host.ClearOverlay());
+                foreach (var win in _fullscreenWindows.Values.ToList())
+                {
+                    if (win?.HostControl != null) InvokeOnUi(() => win.HostControl.ClearOverlay());
+                }
+            }
+            catch { }
         }
 
         /// <summary>

--- a/Rendering/RendererManager.cs
+++ b/Rendering/RendererManager.cs
@@ -196,9 +196,14 @@ namespace ProjectionMapper.Rendering
             }
         }
 
+        // Track multiple mesh overlays per monitor (or main host)
+        private readonly Dictionary<int, List<(Point[] QuadPoints, bool ShowPoints, string LayerId)>> _monitorMeshOverlays = new();
+        private readonly List<(Point[] QuadPoints, bool ShowPoints, string LayerId)> _mainHostMeshOverlays = new();
+
         /// <summary>
         /// Set mesh overlay (quad outline and optional points) on either the main attached host or a fullscreen host for a monitor.
         /// If monitorIndex is null, the main attached host will be used. If quadPoints is null the overlay will be cleared.
+        /// This method only sets a single overlay and clears others - use SetMultipleMeshOverlaysForMonitor for multiple overlays.
         /// </summary>
         public void SetMeshOverlayForMonitor(int? monitorIndex, Point[]? quadPoints, bool showPoints)
         {
@@ -230,12 +235,134 @@ namespace ProjectionMapper.Rendering
         }
 
         /// <summary>
+        /// Add a mesh overlay for a specific layer to a monitor. Multiple overlays can be added and all will be displayed.
+        /// </summary>
+        public void AddMeshOverlayForMonitor(int? monitorIndex, Point[]? quadPoints, bool showPoints, string layerId)
+        {
+            if (!ShowMeshOverlay || quadPoints == null || quadPoints.Length < 4) return;
+
+            try
+            {
+                if (monitorIndex.HasValue)
+                {
+                    if (!_monitorMeshOverlays.ContainsKey(monitorIndex.Value))
+                        _monitorMeshOverlays[monitorIndex.Value] = new List<(Point[], bool, string)>();
+
+                    // Remove any existing overlay for this layer
+                    _monitorMeshOverlays[monitorIndex.Value].RemoveAll(x => x.LayerId == layerId);
+                    
+                    // Add the new overlay
+                    _monitorMeshOverlays[monitorIndex.Value].Add((quadPoints, showPoints, layerId));
+
+                    // Update the display
+                    RefreshMeshOverlaysForMonitor(monitorIndex.Value);
+                }
+                else
+                {
+                    // Remove any existing overlay for this layer
+                    _mainHostMeshOverlays.RemoveAll(x => x.LayerId == layerId);
+                    
+                    // Add the new overlay
+                    _mainHostMeshOverlays.Add((quadPoints, showPoints, layerId));
+
+                    // Update the display
+                    RefreshMeshOverlaysForMainHost();
+                }
+            }
+            catch (Exception ex) { Debug.WriteLine($"AddMeshOverlayForMonitor failed: {ex}"); }
+        }
+
+        /// <summary>
+        /// Remove a mesh overlay for a specific layer from a monitor.
+        /// </summary>
+        public void RemoveMeshOverlayForMonitor(int? monitorIndex, string layerId)
+        {
+            try
+            {
+                if (monitorIndex.HasValue)
+                {
+                    if (_monitorMeshOverlays.TryGetValue(monitorIndex.Value, out var overlays))
+                    {
+                        overlays.RemoveAll(x => x.LayerId == layerId);
+                        RefreshMeshOverlaysForMonitor(monitorIndex.Value);
+                    }
+                }
+                else
+                {
+                    _mainHostMeshOverlays.RemoveAll(x => x.LayerId == layerId);
+                    RefreshMeshOverlaysForMainHost();
+                }
+            }
+            catch (Exception ex) { Debug.WriteLine($"RemoveMeshOverlayForMonitor failed: {ex}"); }
+        }
+
+        private void RefreshMeshOverlaysForMonitor(int monitorIndex)
+        {
+            try
+            {
+                if (_fullscreenWindows.TryGetValue(monitorIndex, out var win) && win != null)
+                {
+                    InvokeOnUi(() =>
+                    {
+                        try
+                        {
+                            // Clear existing mesh overlays first
+                            win.HostControl.ClearMeshOverlay();
+
+                            // Draw all overlays for this monitor using AddMeshOverlay to show multiple
+                            if (_monitorMeshOverlays.TryGetValue(monitorIndex, out var overlays))
+                            {
+                                foreach (var (quadPoints, showPoints, layerId) in overlays)
+                                {
+                                    win.HostControl.AddMeshOverlay(quadPoints, showPoints);
+                                }
+                            }
+                        }
+                        catch (Exception ex) { Debug.WriteLine($"RefreshMeshOverlaysForMonitor inner failed: {ex}"); }
+                    });
+                }
+            }
+            catch (Exception ex) { Debug.WriteLine($"RefreshMeshOverlaysForMonitor failed: {ex}"); }
+        }
+
+        private void RefreshMeshOverlaysForMainHost()
+        {
+            try
+            {
+                if (_host != null)
+                {
+                    InvokeOnUi(() =>
+                    {
+                        try
+                        {
+                            // Clear existing mesh overlays first
+                            _host.ClearMeshOverlay();
+
+                            // Draw all overlays for main host using AddMeshOverlay to show multiple
+                            foreach (var (quadPoints, showPoints, layerId) in _mainHostMeshOverlays)
+                            {
+                                _host.AddMeshOverlay(quadPoints, showPoints);
+                            }
+                        }
+                        catch (Exception ex) { Debug.WriteLine($"RefreshMeshOverlaysForMainHost inner failed: {ex}"); }
+                    });
+                }
+            }
+            catch (Exception ex) { Debug.WriteLine($"RefreshMeshOverlaysForMainHost failed: {ex}"); }
+        }
+
+        /// <summary>
         /// Clear overlays on all hosts (main and fullscreen).
         /// </summary>
         public void ClearAllOverlays()
         {
             try
             {
+                // Clear the tracking collections
+                _monitorMeshOverlays.Clear();
+                _mainHostMeshOverlays.Clear();
+
+                // Clear visual overlays on hosts
                 if (_host != null) InvokeOnUi(() => _host.ClearOverlay());
                 foreach (var win in _fullscreenWindows.Values.ToList())
                 {
@@ -356,11 +483,23 @@ namespace ProjectionMapper.Rendering
         {
             if (_disposed) return;
             _disposed = true;
-
             _renderer.FrameReady -= OnFrameReady;
-            _ = StopAsync();
-            _renderLoop?.Dispose();
-            _renderer.Dispose();
+
+            try
+            {
+                // Stop the render loop synchronously to ensure no further RenderFrameAsync calls
+                // are made against the renderer while we are disposing it. Use GetAwaiter().GetResult()
+                // to synchronously wait for StopAsync to complete on dispose.
+                try { StopAsync().GetAwaiter().GetResult(); } catch (Exception exStop) { Debug.WriteLine($"RendererManager.Dispose: StopAsync failed: {exStop}"); }
+
+                // Dispose the render loop and renderer after stopping the loop.
+                try { _renderLoop?.Dispose(); } catch (Exception exLoop) { Debug.WriteLine($"RendererManager.Dispose: renderLoop.Dispose failed: {exLoop}"); }
+                try { _renderer.Dispose(); } catch (Exception exR) { Debug.WriteLine($"RendererManager.Dispose: renderer.Dispose failed: {exR}"); }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"RendererManager.Dispose: unexpected error while stopping renderer: {ex}");
+            }
 
             foreach (var win in _fullscreenWindows.Values.ToList())
             {

--- a/Rendering/RendererManager.cs
+++ b/Rendering/RendererManager.cs
@@ -33,6 +33,17 @@ namespace ProjectionMapper.Rendering
             ShowMeshOverlay = true; // enabled by default
         }
 
+        public async Task ResizeAsync(int width, int height, CancellationToken token = default)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(RendererManager));
+            await _renderer.ResizeAsync(width, height, token).ConfigureAwait(false);
+            OutputWidth = width; OutputHeight = height;
+        }
+
+        // Current renderer output size in pixels (set when StartAsync is called)
+        public int OutputWidth { get; private set; }
+        public int OutputHeight { get; private set; }
+
         /// <summary>
         /// When true, mesh overlay (quad outline and points) will be shown on output hosts when provided.
         /// </summary>
@@ -50,22 +61,26 @@ namespace ProjectionMapper.Rendering
             {
                 BitmapSource? frame = null;
 
-                // If a specific monitor index is requested, prefer that fullscreen host's current frame
+                // If a specific monitor index is requested and a fullscreen host exists for it, prefer that host's current frame
+                // because the mapping should use the pixel space of the target display. Otherwise fall back to the main attached host.
                 if (monitorIndex.HasValue && _fullscreenWindows.TryGetValue(monitorIndex.Value, out var win) && win != null)
                 {
                     try { frame = win.HostControl?.CurrentFrame; }
                     catch (Exception ex) { Debug.WriteLine($"MapNormalizedToRendererPoints: failed reading fullscreen host frame: {ex}"); frame = null; }
                 }
 
-                // Fallback to main attached host
+                // Fallback to main attached host if fullscreen host not available
                 if (frame == null)
                 {
                     if (_host == null) return null;
                     frame = _host.CurrentFrame;
                 }
-                if (frame == null) return null;
-                double w = frame.PixelWidth;
-                double h = frame.PixelHeight;
+                // Prefer using the renderer's canonical output size when available so normalized coordinates
+                // map into renderer pixel space deterministically. Fall back to the host frame pixel size
+                // only if the renderer output size is not known.
+                double w = OutputWidth > 0 ? OutputWidth : (frame?.PixelWidth ?? 0);
+                double h = OutputHeight > 0 ? OutputHeight : (frame?.PixelHeight ?? 0);
+                if (w <= 0 || h <= 0) return null;
                 var pts = new Point[4];
                 for (int i = 0; i < 4; ++i)
                 {

--- a/Services/VideoService.cs
+++ b/Services/VideoService.cs
@@ -213,6 +213,7 @@ namespace ProjectionMapper.Services
                     BitmapSource frameForMesh = bmpToSubmit;
                     try
                     {
+                        // Crop to the mesh's MeshPoints (input selection) so only the selected portion is submitted to renderer
                         float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
                         foreach (var p in mesh.MeshPoints)
                         {
@@ -336,36 +337,33 @@ namespace ProjectionMapper.Services
                     BitmapSource frameForMesh = sourceFrame;
                     try
                     {
-                        float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
-                        foreach (var p in mesh.MeshPoints)
-                        {
-                            minX = Math.Min(minX, p.X);
-                            minY = Math.Min(minY, p.Y);
-                            maxX = Math.Max(maxX, p.X);
-                            maxY = Math.Max(maxY, p.Y);
-                        }
-
-                        minX = Math.Max(0f, Math.Min(1f, minX));
-                        minY = Math.Max(0f, Math.Min(1f, minY));
-                        maxX = Math.Max(0f, Math.Min(1f, maxX));
-                        maxY = Math.Max(0f, Math.Min(1f, maxY));
-
-                        int srcW = frameForMesh.PixelWidth; int srcH = frameForMesh.PixelHeight;
-                        int srcX = (int)Math.Floor(minX * srcW);
-                        int srcY = (int)Math.Floor(minY * srcH);
-                        int cropW = Math.Max(1, (int)Math.Ceiling((maxX - minX) * srcW));
-                        int cropH = Math.Max(1, (int)Math.Ceiling((maxY - minY) * srcH));
-
-                        if (srcX < 0) srcX = 0; if (srcY < 0) srcY = 0;
-                        if (srcX + cropW > srcW) cropW = srcW - srcX;
-                        if (srcY + cropH > srcH) cropH = srcH - srcY;
-
-                        if (cropW > 0 && cropH > 0)
-                        {
-                            var cb = new CroppedBitmap(frameForMesh, new Int32Rect(srcX, srcY, cropW, cropH));
-                            try { cb.Freeze(); } catch { }
-                            frameForMesh = cb;
-                        }
+                        // Removed cropping to stretch the full source frame to fill the output mesh
+                        // float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
+                        // foreach (var p in mesh.MeshPoints)
+                        // {
+                        //     minX = Math.Min(minX, p.X);
+                        //     minY = Math.Min(minY, p.Y);
+                        //     maxX = Math.Max(maxX, p.X);
+                        //     maxY = Math.Max(maxY, p.Y);
+                        // }
+                        // minX = Math.Max(0f, Math.Min(1f, minX));
+                        // minY = Math.Max(0f, Math.Min(1f, minY));
+                        // maxX = Math.Max(0f, Math.Min(1f, maxX));
+                        // maxY = Math.Max(0f, Math.Min(1f, maxY));
+                        // int srcW = frameForMesh.PixelWidth; int srcH = frameForMesh.PixelHeight;
+                        // int srcX = (int)Math.Floor(minX * srcW);
+                        // int srcY = (int)Math.Floor(minY * srcH);
+                        // int cropW = Math.Max(1, (int)Math.Ceiling((maxX - minX) * srcW));
+                        // int cropH = Math.Max(1, (int)Math.Ceiling((maxY - minY) * srcH));
+                        // if (srcX < 0) srcX = 0; if (srcY < 0) srcY = 0;
+                        // if (srcX + cropW > srcW) cropW = srcW - srcX;
+                        // if (srcY + cropH > srcH) cropH = srcH - srcY;
+                        // if (cropW > 0 && cropH > 0)
+                        // {
+                        //     var cb = new CroppedBitmap(frameForMesh, new Int32Rect(srcX, srcY, cropW, cropH));
+                        //     try { cb.Freeze(); } catch { }
+                        //     frameForMesh = cb;
+                        // }
                     }
                     catch { frameForMesh = sourceFrame; }
 
@@ -713,36 +711,33 @@ namespace ProjectionMapper.Services
                             var frameForMesh = tup.lastFrame;
                             try
                             {
-                                float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
-                                foreach (var p in mesh.MeshPoints)
-                                {
-                                    minX = Math.Min(minX, p.X);
-                                    minY = Math.Min(minY, p.Y);
-                                    maxX = Math.Max(maxX, p.X);
-                                    maxY = Math.Max(maxY, p.Y);
-                                }
-
-                                minX = Math.Max(0f, Math.Min(1f, minX));
-                                minY = Math.Max(0f, Math.Min(1f, minY));
-                                maxX = Math.Max(0f, Math.Min(1f, maxX));
-                                maxY = Math.Max(0f, Math.Min(1f, maxY));
-
-                                int srcW = frameForMesh.PixelWidth; int srcH = frameForMesh.PixelHeight;
-                                int srcX = (int)Math.Floor(minX * srcW);
-                                int srcY = (int)Math.Floor(minY * srcH);
-                                int cropW = Math.Max(1, (int)Math.Ceiling((maxX - minX) * srcW));
-                                int cropH = Math.Max(1, (int)Math.Ceiling((maxY - minY) * srcH));
-
-                                if (srcX < 0) srcX = 0; if (srcY < 0) srcY = 0;
-                                if (srcX + cropW > srcW) cropW = srcW - srcX;
-                                if (srcY + cropH > srcH) cropH = srcH - srcY;
-
-                                if (cropW > 0 && cropH > 0)
-                                {
-                                    var cb = new CroppedBitmap(frameForMesh, new Int32Rect(srcX, srcY, cropW, cropH));
-                                    try { cb.Freeze(); } catch { }
-                                    frameForMesh = cb;
-                                }
+                                // Removed cropping to stretch the full source frame to fill the output mesh
+                                // float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
+                                // foreach (var p in mesh.MeshPoints)
+                                // {
+                                //     minX = Math.Min(minX, p.X);
+                                //     minY = Math.Min(minY, p.Y);
+                                //     maxX = Math.Max(maxX, p.X);
+                                //     maxY = Math.Max(maxY, p.Y);
+                                // }
+                                // minX = Math.Max(0f, Math.Min(1f, minX));
+                                // minY = Math.Max(0f, Math.Min(1f, minY));
+                                // maxX = Math.Max(0f, Math.Min(1f, maxX));
+                                // maxY = Math.Max(0f, Math.Min(1f, maxY));
+                                // int srcW = frameForMesh.PixelWidth; int srcH = frameForMesh.PixelHeight;
+                                // int srcX = (int)Math.Floor(minX * srcW);
+                                // int srcY = (int)Math.Floor(minY * srcH);
+                                // int cropW = Math.Max(1, (int)Math.Ceiling((maxX - minX) * srcW));
+                                // int cropH = Math.Max(1, (int)Math.Ceiling((maxY - minY) * srcH));
+                                // if (srcX < 0) srcX = 0; if (srcY < 0) srcY = 0;
+                                // if (srcX + cropW > srcW) cropW = srcW - srcX;
+                                // if (srcY + cropH > srcH) cropH = srcH - srcY;
+                                // if (cropW > 0 && cropH > 0)
+                                // {
+                                //     var cb = new CroppedBitmap(frameForMesh, new Int32Rect(srcX, srcY, cropW, cropH));
+                                //     try { cb.Freeze(); } catch { }
+                                //     frameForMesh = cb;
+                                // }
                             }
                             catch { }
 

--- a/ViewModels/LayerViewModel.cs
+++ b/ViewModels/LayerViewModel.cs
@@ -155,5 +155,16 @@ namespace ProjectionMapper.ViewModels
                 RaisePropertyChanged();
             }
         }
+
+        public bool ShowOverlay
+        {
+            get => _model.ShowOverlay;
+            set
+            {
+                if (_model.ShowOverlay == value) return;
+                _model.ShowOverlay = value;
+                RaisePropertyChanged();
+            }
+        }
     }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -212,15 +212,11 @@ namespace ProjectionMapper.ViewModels
             // create a mesh layer linked to the host
             var host = SelectedImportedVideo.HostLayer;
 
-            // Default to a centered, smaller rect (50% of host) so multiple layers are easier to work with
-            int defaultW = 640, defaultH = 360, defaultX = 0, defaultY = 0;
-            if (host != null && host.Width > 0 && host.Height > 0)
-            {
-                defaultW = Math.Max(1, host.Width / 2);
-                defaultH = Math.Max(1, host.Height / 2);
-                defaultX = host.X + (host.Width - defaultW) / 2;
-                defaultY = host.Y + (host.Height - defaultH) / 2;
-            }
+            // Default to a centered, smaller rect (20% of host) so multiple layers are easier to work with
+            int defaultW = Math.Max(1, host.Width / 5);
+            int defaultH = Math.Max(1, host.Height / 5);
+            int defaultX = host.X + (host.Width - defaultW) / 2;
+            int defaultY = host.Y + (host.Height - defaultH) / 2;
 
             var layerModel = new LayerModel
             {

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -57,13 +57,11 @@
                     </Button.Content>
                 </Button>
 
-                <Button Content="Preview" Command="{Binding PreviewCommand}" />
-
                 <Separator />
                 <TextBlock Text="Input Zoom" VerticalAlignment="Center" Margin="8,0,4,0" />
-                <Slider Width="120" Minimum="0.1" Maximum="4" Value="{Binding InputZoom, Mode=TwoWay}" />
+                <Slider Width="120" Minimum="0.5" Maximum="4" Value="{Binding InputZoom, Mode=TwoWay}" />
                 <TextBlock Text="Output Zoom" VerticalAlignment="Center" Margin="8,0,4,0" />
-                <Slider Width="120" Minimum="0.1" Maximum="4" Value="{Binding OutputZoom, Mode=TwoWay}" />
+                <Slider Width="120" Minimum="0.5" Maximum="4" Value="{Binding OutputZoom, Mode=TwoWay}" />
             </ToolBar>
         </ToolBarTray>
 
@@ -133,6 +131,8 @@
                     <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                         <TextBlock Text="Show Mesh Overlay (global):" VerticalAlignment="Center" Margin="0,0,6,0" />
                         <CheckBox x:Name="PART_GlobalShowMeshOverlayCheckbox" IsChecked="True" VerticalAlignment="Center" />
+                        <TextBlock Text="Show Coordinate Grid:" VerticalAlignment="Center" Margin="12,0,6,0" />
+                        <CheckBox x:Name="PART_ShowGridCheckbox" IsChecked="False" VerticalAlignment="Center" />
                     </StackPanel>
                     <!-- Simple inspector for selected mesh layer -->
                     <StackPanel DataContext="{Binding SelectedMeshLayer}" Margin="0,8,0,0">

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -232,7 +232,11 @@
                                 <views:RenderHostControl x:Name="PART_OutputHost" />
 
                                 <!-- Output mesh editor binds to SelectedMeshLayer so output rect is adjustable -->
-                                <views:OutputMeshEditorControl SelectedLayer="{Binding SelectedMeshLayer, Mode=TwoWay}" VideoService="{DynamicResource VideoService}" HostRenderHost="{Binding ElementName=PART_OutputHost}" RendererManager="{DynamicResource RendererManager}" />
+                                <views:OutputMeshEditorControl SelectedLayer="{Binding SelectedMeshLayer, Mode=TwoWay}" 
+                                                               AllMeshLayers="{Binding SelectedImportedVideo.MeshLayers, Mode=OneWay}"
+                                                               VideoService="{DynamicResource VideoService}" 
+                                                               HostRenderHost="{Binding ElementName=PART_OutputHost}" 
+                                                               RendererManager="{DynamicResource RendererManager}" />
                             </Grid>
                         </ScrollViewer>
                     </DockPanel>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -207,6 +207,7 @@
                                 <views:RenderHostControl x:Name="PART_InputHost" />
                                 <views:MeshEditorControl x:Name="PART_MeshEditor" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                                                          SelectedLayer="{Binding SelectedMeshLayer, Mode=TwoWay}"
+                                                         AllMeshLayers="{Binding SelectedImportedVideo.MeshLayers, Mode=OneWay}"
                                                          SelectedSourceId="{Binding SelectedImportedVideo.HostLayer.Id, Mode=OneWay}"
                                                          VideoService="{DynamicResource VideoService}"
                                                          RendererManager="{DynamicResource RendererManager}"

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -130,6 +130,10 @@
                     <Separator Margin="0,8,0,8" />
 
                     <TextBlock FontWeight="Bold" Text="Properties" Margin="0,0,0,8"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                        <TextBlock Text="Show Mesh Overlay (global):" VerticalAlignment="Center" Margin="0,0,6,0" />
+                        <CheckBox x:Name="PART_GlobalShowMeshOverlayCheckbox" IsChecked="True" VerticalAlignment="Center" />
+                    </StackPanel>
                     <!-- Simple inspector for selected mesh layer -->
                     <StackPanel DataContext="{Binding SelectedMeshLayer}" Margin="0,8,0,0">
                         <TextBlock Text="Selected:" FontWeight="Bold" />
@@ -151,6 +155,10 @@
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                 <TextBlock Text="Output Display:" VerticalAlignment="Center" Margin="0,0,6,0" />
                                 <ComboBox x:Name="PART_MeshMonitorCombo" Width="150" SelectedIndex="-1" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0" VerticalAlignment="Center">
+                                <TextBlock Text="Show Mesh Overlay on Output:" VerticalAlignment="Center" Margin="0,0,6,0" />
+                                <CheckBox x:Name="PART_ShowMeshOverlayCheckbox" IsChecked="True" VerticalAlignment="Center" />
                             </StackPanel>
                         </StackPanel>
                     </StackPanel>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -125,6 +125,25 @@ namespace ProjectionMapper
 
                 // Wire up audio control event handlers
                 HookAudioControls();
+
+                // Wire mesh overlay checkbox
+                try
+                {
+                    if (PART_ShowMeshOverlayCheckbox != null)
+                    {
+                        PART_ShowMeshOverlayCheckbox.Checked += (s, e) => { _rendererManager.ShowMeshOverlay = true; };
+                        PART_ShowMeshOverlayCheckbox.Unchecked += (s, e) => { _rendererManager.ShowMeshOverlay = false; _rendererManager.ClearAllOverlays(); };
+                        // default checked
+                        PART_ShowMeshOverlayCheckbox.IsChecked = _rendererManager.ShowMeshOverlay;
+                    }
+                    if (PART_GlobalShowMeshOverlayCheckbox != null)
+                    {
+                        PART_GlobalShowMeshOverlayCheckbox.Checked += (s, e) => { _rendererManager.ShowMeshOverlay = true; };
+                        PART_GlobalShowMeshOverlayCheckbox.Unchecked += (s, e) => { _rendererManager.ShowMeshOverlay = false; _rendererManager.ClearAllOverlays(); };
+                        PART_GlobalShowMeshOverlayCheckbox.IsChecked = _rendererManager.ShowMeshOverlay;
+                    }
+                }
+                catch { }
             };
 
             // Start renderer (use output host size; fallback to 1280x720)

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -244,7 +244,37 @@ namespace ProjectionMapper
             {
                 if (mesh != null && !string.IsNullOrEmpty(mesh.Id))
                 {
+                    try
+                    {
+                        // If the user has selected a monitor for the imported video, ensure the new mesh
+                        // inherits that target so overlays and compositor mapping apply to the same output host.
+                        var imported = _vm.SelectedImportedVideo;
+                        if (imported?.HostLayer != null)
+                        {
+                            mesh.TargetMonitorIndex = imported.HostLayer.TargetMonitorIndex;
+                        }
+                    }
+                    catch { }
+
                     await _videoService.RegisterMeshLayerAsync(mesh);
+
+                    // Also update all mesh overlays to include the new mesh layer
+                    UpdateAllMeshOverlaysForImportedVideo(_vm.SelectedImportedVideo);
+
+                    // If this mesh targets a fullscreen monitor, push the current composed frame to that fullscreen host
+                    try
+                    {
+                        var target = mesh.TargetMonitorIndex;
+                        if (target >= 0)
+                        {
+                            var current = PART_OutputHost?.CurrentFrame;
+                            if (current != null)
+                            {
+                                _rendererManager.SetFullScreenHostFrame(target, current);
+                            }
+                        }
+                    }
+                    catch { }
                 }
             };
         }
@@ -459,6 +489,9 @@ namespace ProjectionMapper
                     // hide any existing fullscreen for this index
                     _rendererManager.HideFullScreenWindow(item.Index);
                 }
+
+                // Update all mesh overlays for the new monitor
+                UpdateAllMeshOverlaysForImportedVideo(imported);
             }
         }
 
@@ -566,6 +599,9 @@ namespace ProjectionMapper
                 {
                     PART_MeshMonitorCombo.SelectedIndex = layerVm.Model.TargetMonitorIndex >= 0 ? layerVm.Model.TargetMonitorIndex : -1;
                 }
+                
+                // Update all mesh overlays for the target monitor
+                UpdateAllMeshOverlaysForImportedVideo(_vm.SelectedImportedVideo);
                 return;
             }
 
@@ -593,12 +629,54 @@ namespace ProjectionMapper
                 }
                 catch { }
 
+                // Update all mesh overlays for this imported video
+                UpdateAllMeshOverlaysForImportedVideo(imported);
                 return;
             }
 
             // Otherwise clear selections
             _vm.SelectedImportedVideo = null;
             _vm.SelectedMeshLayer = null;
+        }
+
+        private void UpdateAllMeshOverlaysForImportedVideo(ImportedVideoViewModel? imported)
+        {
+            if (imported == null) return;
+
+            try
+            {
+                var targetMonitor = imported.HostLayer?.TargetMonitorIndex ?? -1;
+                
+                // Update overlays for all mesh layers of this imported video
+                foreach (var meshVm in imported.MeshLayers)
+                {
+                    if (meshVm?.Model == null) continue;
+                    
+                    var layerId = meshVm.Model.Id;
+                    if (string.IsNullOrEmpty(layerId)) continue;
+                    
+                    var showOverlayPref = meshVm.Model.ShowOverlay;
+                    if (!showOverlayPref) continue;
+
+                    try
+                    {
+                        // Map normalized output mesh points to renderer coordinates
+                        Point[]? quadForRenderer = null;
+                        try
+                        {
+                            quadForRenderer = _rendererManager?.MapNormalizedToRendererPoints(meshVm.OutputMeshPoints, targetMonitor >= 0 ? targetMonitor : null);
+                        }
+                        catch { quadForRenderer = null; }
+
+                        if (quadForRenderer != null && quadForRenderer.Length >= 4)
+                        {
+                            _rendererManager?.AddMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, quadForRenderer, true, layerId);
+                        }
+                    }
+                    catch { }
+                }
+            }
+            catch { }
         }
 
         // Ensure right-click selects the TreeViewItem under the mouse so context menu actions apply to it
@@ -885,26 +963,37 @@ namespace ProjectionMapper
 
         private static List<MonitorInfo> EnumerateMonitors()
         {
-            var list = new List<MonitorInfo>();
-
-            MonitorEnumDelegate del = (IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData) =>
+            try
             {
-                var mi = new MONITORINFOEX();
-                mi.cbSize = Marshal.SizeOf<MONITORINFOEX>();
-                if (GetMonitorInfo(hMonitor, ref mi))
+                var list = new List<MonitorInfo>();
+
+                MonitorEnumDelegate del = (IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData) =>
                 {
-                    var w = mi.rcMonitor.Right - mi.rcMonitor.Left;
-                    var h = mi.rcMonitor.Bottom - mi.rcMonitor.Top;
-                    var l = mi.rcMonitor.Left;
-                    var t = mi.rcMonitor.Top;
-                    list.Add(new MonitorInfo(w, h, l, t));
-                }
-                return true;
-            };
+                    try
+                    {
+                        var mi = new MONITORINFOEX();
+                        mi.cbSize = Marshal.SizeOf<MONITORINFOEX>();
+                        if (GetMonitorInfo(hMonitor, ref mi))
+                        {
+                            var w = mi.rcMonitor.Right - mi.rcMonitor.Left;
+                            var h = mi.rcMonitor.Bottom - mi.rcMonitor.Top;
+                            var l = mi.rcMonitor.Left;
+                            var t = mi.rcMonitor.Top;
+                            list.Add(new MonitorInfo(w, h, l, t));
+                        }
+                    }
+                    catch { }
+                    return true;
+                };
 
-            EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, del, IntPtr.Zero);
+                EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, del, IntPtr.Zero);
 
-            return list;
+                return list;
+            }
+            catch
+            {
+                return new List<MonitorInfo>();
+            }
         }
 
         private delegate bool MonitorEnumDelegate(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData);

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -44,6 +44,61 @@ namespace ProjectionMapper
             public override string ToString() => Name;
         }
 
+        private void PART_MonitorCombo_DropDownOpened(object? sender, EventArgs e)
+        {
+            try
+            {
+                RefreshMonitors();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"PART_MonitorCombo_DropDownOpened: failed to refresh monitors: {ex}");
+            }
+        }
+
+        private void RefreshMonitors()
+        {
+            try
+            {
+                // remember current selection so we can restore if possible
+                int prevSelected = -1;
+                try { prevSelected = PART_MonitorCombo != null ? PART_MonitorCombo.SelectedIndex : -1; } catch { prevSelected = -1; }
+
+                var newMonitors = EnumerateMonitors();
+
+                // update internal list
+                _monitors = newMonitors;
+
+                // rebuild ObservableCollection of items on UI thread
+                Dispatcher.Invoke(() =>
+                {
+                    _monitorItems.Clear();
+                    for (int i = 0; i < _monitors.Count; i++)
+                    {
+                        var m = _monitors[i];
+                        _monitorItems.Add(new MonitorItem { Index = i, Name = $"Display {i + 1} ({m.Width}x{m.Height})" });
+                    }
+
+                    // try to restore previous selection if still valid
+                    if (PART_MonitorCombo != null)
+                    {
+                        if (prevSelected >= 0 && prevSelected < _monitorItems.Count)
+                        {
+                            PART_MonitorCombo.SelectedIndex = prevSelected;
+                        }
+                        else
+                        {
+                            PART_MonitorCombo.SelectedIndex = -1;
+                        }
+                    }
+                }, DispatcherPriority.Normal);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"RefreshMonitors: failed: {ex}");
+            }
+        }
+
         public MainWindow()
         {
             InitializeComponent();
@@ -117,6 +172,8 @@ namespace ProjectionMapper
                 {
                     PART_MonitorCombo.ItemsSource = _monitorItems;
                     PART_MonitorCombo.SelectionChanged += PART_MonitorCombo_SelectionChanged;
+                    // Re-scan displays each time the drop-down is opened so available monitors are up-to-date
+                    try { PART_MonitorCombo.DropDownOpened += PART_MonitorCombo_DropDownOpened; } catch { }
                 }
                 // We prefer a single monitor combo for selecting the output monitor for the selected source.
                 // Hide the per-mesh combo to avoid duplicate controls; the PART_MonitorCombo will be used to
@@ -141,6 +198,24 @@ namespace ProjectionMapper
                         PART_GlobalShowMeshOverlayCheckbox.Checked += (s, e) => { _rendererManager.ShowMeshOverlay = true; };
                         PART_GlobalShowMeshOverlayCheckbox.Unchecked += (s, e) => { _rendererManager.ShowMeshOverlay = false; _rendererManager.ClearAllOverlays(); };
                         PART_GlobalShowMeshOverlayCheckbox.IsChecked = _rendererManager.ShowMeshOverlay;
+                    }
+                    // Show grid checkbox - call SetCoordinateGrid on output host when checked
+                    if (PART_ShowGridCheckbox != null)
+                    {
+                        PART_ShowGridCheckbox.Checked += (s, e) =>
+                        {
+                            try
+                            {
+                                // display grid every 100 renderer pixels by default
+                                PART_OutputHost?.SetCoordinateGrid(100);
+                            }
+                            catch { }
+                        };
+                        PART_ShowGridCheckbox.Unchecked += (s, e) =>
+                        {
+                            try { PART_OutputHost?.ClearGridOverlay(); } catch { }
+                        };
+                        PART_ShowGridCheckbox.IsChecked = false;
                     }
                 }
                 catch { }

--- a/Views/MeshEditorControl.xaml.cs
+++ b/Views/MeshEditorControl.xaml.cs
@@ -79,8 +79,6 @@ namespace ProjectionMapper.Views
 
             Loaded += (_, __) => ApplyLayout();
             Unloaded += (_, __) => OnUnloaded();
-
-            Task.Run(() => BackgroundUpdateLoop(_cts.Token), _cts.Token);
         }
 
         private void OnUnloaded()
@@ -104,8 +102,7 @@ namespace ProjectionMapper.Views
         public VideoService? VideoService
         {
             get => (VideoService?)GetValue(VideoServiceProperty);
-            set => SetValue(VideoServiceProperty, value);
-        }
+            set => SetValue(VideoServiceProperty, value);        }
 
         private static void OnVideoServiceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -262,6 +259,9 @@ namespace ProjectionMapper.Views
                 // fallback: show combined render host frame if available
                 SafeUpdateInputImageFromHost();
             }
+
+            // Update all external overlays when selection changes
+            UpdateAllExternalOverlays();
         }
 
         private void OnAllMeshLayersChanged(System.Collections.ObjectModel.ObservableCollection<LayerViewModel>? oldCollection, 
@@ -273,10 +273,21 @@ namespace ProjectionMapper.Views
             if (oldCollection != null)
             {
                 oldCollection.CollectionChanged -= AllMeshLayers_CollectionChanged;
-                // Unsubscribe from property changes of individual layers
+                // Unsubscribe from property changes of individual layers and remove their overlays
                 foreach (var layer in oldCollection)
                 {
                     try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                    
+                    // Remove overlay for this layer
+                    if (layer?.Model?.Id != null && _rendererManager != null)
+                    {
+                        var targetMonitor = layer.Model.TargetMonitorIndex;
+                        try 
+                        { 
+                            _rendererManager.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layer.Model.Id); 
+                        } 
+                        catch { }
+                    }
                 }
             }
 
@@ -291,13 +302,18 @@ namespace ProjectionMapper.Views
                 }
             }
 
-            // Refresh the display to show all mesh layer outlines
+            // Refresh the display to show all mesh layer outlines and external overlays
             RefreshAllMeshLayerOverlays();
+            UpdateAllExternalOverlays();
+
+            System.Diagnostics.Debug.WriteLine($"OnAllMeshLayersChanged: {newCollection?.Count ?? 0} layers");
         }
 
         private void AllMeshLayers_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             if (_isDisposed) return;
+
+            System.Diagnostics.Debug.WriteLine($"AllMeshLayers_CollectionChanged: Action={e.Action}");
 
             // Handle added items
             if (e.NewItems != null)
@@ -305,6 +321,10 @@ namespace ProjectionMapper.Views
                 foreach (LayerViewModel layer in e.NewItems)
                 {
                     try { layer.PropertyChanged += AllMeshLayer_PropertyChanged; } catch { }
+                    System.Diagnostics.Debug.WriteLine($"  Added layer: {layer.Name} (ID: {layer.Id})");
+                    
+                    // Add overlay for the new layer immediately
+                    UpdateExternalOverlayForLayer(layer);
                 }
             }
 
@@ -314,10 +334,22 @@ namespace ProjectionMapper.Views
                 foreach (LayerViewModel layer in e.OldItems)
                 {
                     try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                    System.Diagnostics.Debug.WriteLine($"  Removed layer: {layer.Name} (ID: {layer.Id})");
+                    
+                    // Remove overlay for this layer
+                    if (layer?.Model?.Id != null && _rendererManager != null)
+                    {
+                        var targetMonitor = layer.Model.TargetMonitorIndex;
+                        try 
+                        { 
+                            _rendererManager.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layer.Model.Id); 
+                        } 
+                        catch { }
+                    }
                 }
             }
 
-            // Refresh the display
+            // Refresh the display for UI overlays (this is separate from external overlays)
             RefreshAllMeshLayerOverlays();
         }
 
@@ -325,21 +357,34 @@ namespace ProjectionMapper.Views
         {
             if (_isDisposed || _suppressVmRebind) return;
 
-            // Only refresh if mesh points changed for any layer
-            if (e == null || e.PropertyName == nameof(LayerViewModel.MeshPoints) || string.IsNullOrEmpty(e.PropertyName))
+            // Only update external overlays for relevant property changes and only for the specific layer
+            if (e == null || string.IsNullOrEmpty(e.PropertyName) ||
+                e.PropertyName == nameof(LayerViewModel.MeshPoints) || 
+                e.PropertyName == nameof(LayerViewModel.OutputMeshPoints) ||
+                e.PropertyName == nameof(LayerViewModel.ShowOverlay) ||
+                e.PropertyName == nameof(LayerViewModel.Visible))
             {
-                try 
-                { 
-                    if (!Dispatcher.CheckAccess())
-                    {
-                        Dispatcher.BeginInvoke(() => RefreshAllMeshLayerOverlays());
-                    }
-                    else
-                    {
-                        RefreshAllMeshLayerOverlays();
-                    }
-                } 
-                catch { }
+                // Update only the specific layer that changed, not all layers
+                if (sender is LayerViewModel changedLayer)
+                {
+                    try 
+                    { 
+                        if (!Dispatcher.CheckAccess())
+                        {
+                            Dispatcher.BeginInvoke(() => 
+                            {
+                                RefreshAllMeshLayerOverlays(); // UI overlays still need full refresh
+                                UpdateExternalOverlayForLayer(changedLayer); // Only update this layer's external overlay
+                            });
+                        }
+                        else
+                        {
+                            RefreshAllMeshLayerOverlays(); // UI overlays still need full refresh
+                            UpdateExternalOverlayForLayer(changedLayer); // Only update this layer's external overlay
+                        }
+                    } 
+                    catch { }
+                }
             }
         }
 
@@ -388,18 +433,31 @@ namespace ProjectionMapper.Views
         {
             if (_isDisposed || _suppressVmRebind) return;
 
-            if (e == null || e.PropertyName == nameof(LayerViewModel.MeshPoints) || string.IsNullOrEmpty(e.PropertyName))
+            if (e == null || e.PropertyName == nameof(LayerViewModel.MeshPoints) || e.PropertyName == nameof(LayerViewModel.OutputMeshPoints) || string.IsNullOrEmpty(e.PropertyName))
             {
                 // use BeginInvoke to avoid potential cross-thread issues
                 try 
                 { 
                     if (!Dispatcher.CheckAccess())
                     {
-                        Dispatcher.BeginInvoke(() => MapSelectedLayerMeshToRects());
+                        Dispatcher.BeginInvoke(() => 
+                        {
+                            MapSelectedLayerMeshToRects();
+                            // Only update the selected layer's external overlay, not all layers
+                            if (SelectedLayer != null)
+                            {
+                                UpdateExternalOverlayForLayer(SelectedLayer);
+                            }
+                        });
                     }
                     else
                     {
                         MapSelectedLayerMeshToRects();
+                        // Only update the selected layer's external overlay, not all layers
+                        if (SelectedLayer != null)
+                        {
+                            UpdateExternalOverlayForLayer(SelectedLayer);
+                        }
                     }
                 } 
                 catch { }
@@ -866,10 +924,103 @@ namespace ProjectionMapper.Views
                 var bl = new Vector2((float)(_corners[2].X / cw), (float)(_corners[2].Y / ch));
                 var br = new Vector2((float)(_corners[3].X / cw), (float)(_corners[3].Y / ch));
 
+                // Update input mesh points (source cropping) - this is the primary purpose of input pane
                 vm.SetMeshPoint(0, tl);
                 vm.SetMeshPoint(1, tr);
                 vm.SetMeshPoint(2, bl);
                 vm.SetMeshPoint(3, br);
+
+                // Only update the selected layer's external overlay in real-time, not all layers
+                UpdateExternalOverlayForLayer(vm);
+            }
+            catch { }
+        }
+
+        private void UpdateExternalOverlayForLayer(LayerViewModel layer)
+        {
+            if (_isDisposed || layer?.Model == null || _rendererManager == null) return;
+
+            try
+            {
+                var layerId = layer.Model.Id;
+                if (string.IsNullOrEmpty(layerId)) return;
+
+                var targetMonitor = layer.Model.TargetMonitorIndex;
+
+                var showOverlayPref = layer.Model.ShowOverlay;
+                if (!showOverlayPref) 
+                {
+                    // Remove overlay if disabled
+                    try 
+                    { 
+                        _rendererManager.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layerId); 
+                    } 
+                    catch { }
+                    return;
+                }
+
+                // Choose which mesh points to use for external overlay:
+                // If OutputMeshPoints have been modified from defaults (not all corners at 0,0,1,1), use them
+                // Otherwise, use MeshPoints for the overlay
+                Vector2[]? meshPointsToUse = null;
+                var outputPts = layer.OutputMeshPoints;
+                var inputPts = layer.MeshPoints;
+
+                // Check if OutputMeshPoints are still at default positions (indicating they haven't been edited in output pane)
+                bool outputPtsAreDefault = (outputPts != null && outputPts.Length >= 4 &&
+                    IsPointApproximately(outputPts[0], new Vector2(0f, 0f)) &&
+                    IsPointApproximately(outputPts[1], new Vector2(1f, 0f)) &&
+                    IsPointApproximately(outputPts[2], new Vector2(0f, 1f)) &&
+                    IsPointApproximately(outputPts[3], new Vector2(1f, 1f)));
+
+                // If output points are at defaults, use input points; otherwise use output points
+                meshPointsToUse = outputPtsAreDefault ? inputPts : outputPts;
+
+                // Map chosen mesh points to renderer coordinates
+                Point[]? quadForRenderer = null;
+                try
+                {
+                    quadForRenderer = _rendererManager.MapNormalizedToRendererPoints(meshPointsToUse, targetMonitor >= 0 ? targetMonitor : null);
+                }
+                catch { quadForRenderer = null; }
+
+                if (quadForRenderer != null && quadForRenderer.Length >= 4)
+                {
+                    // Remove existing overlay for this layer first, then add the new one
+                    // This approach is much more efficient than clearing all overlays
+                    try 
+                    { 
+                        _rendererManager.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layerId); 
+                    } 
+                    catch { }
+                    
+                    _rendererManager.AddMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, quadForRenderer, true, layerId);
+                }
+            }
+            catch (Exception ex) 
+            { 
+                System.Diagnostics.Debug.WriteLine($"UpdateExternalOverlayForLayer failed for {layer?.Name}: {ex.Message}");
+            }
+        }
+
+        private static bool IsPointApproximately(Vector2 point, Vector2 target, float tolerance = 0.01f)
+        {
+            return Math.Abs(point.X - target.X) < tolerance && Math.Abs(point.Y - target.Y) < tolerance;
+        }
+
+        private void UpdateAllExternalOverlays()
+        {
+            if (_isDisposed || _rendererManager == null || AllMeshLayers == null) return;
+
+            try
+            {
+                // Don't clear and recreate all overlays - just update each one individually
+                // This prevents exponential performance degradation with multiple mesh layers
+                foreach (var meshLayer in AllMeshLayers)
+                {
+                    if (meshLayer?.Model == null) continue;
+                    UpdateExternalOverlayForLayer(meshLayer);
+                }
             }
             catch { }
         }
@@ -982,3 +1133,5 @@ namespace ProjectionMapper.Views
         }
     }
 }
+
+

--- a/Views/MeshEditorControl.xaml.cs
+++ b/Views/MeshEditorControl.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -8,6 +10,7 @@ using System.Windows.Input;
 using System.Numerics;
 using System.ComponentModel;
 using System.Windows.Media;
+using System.Windows.Shapes;
 using ProjectionMapper.ViewModels;
 using System.Windows.Media.Imaging;
 using ProjectionMapper.Views;
@@ -50,6 +53,10 @@ namespace ProjectionMapper.Views
 
         // suppress reacting to VM changes while user is actively manipulating the mesh
         private bool _suppressVmRebind = false;
+
+        // Collections for tracking all mesh layer visual elements
+        private readonly List<System.Windows.Shapes.Polygon> _allMeshPolygons = new();
+        private readonly List<(Thumb TL, Thumb TR, Thumb BL, Thumb BR, LayerViewModel Layer)> _allMeshHandles = new();
 
         public MeshEditorControl()
         {
@@ -187,6 +194,26 @@ namespace ProjectionMapper.Views
             }
         }
 
+        // New DP for all mesh layers from the selected imported video
+        public static readonly DependencyProperty AllMeshLayersProperty = DependencyProperty.Register(
+            nameof(AllMeshLayers), typeof(System.Collections.ObjectModel.ObservableCollection<LayerViewModel>), typeof(MeshEditorControl),
+            new PropertyMetadata(null, OnAllMeshLayersChanged));
+
+        public System.Collections.ObjectModel.ObservableCollection<LayerViewModel>? AllMeshLayers
+        {
+            get => (System.Collections.ObjectModel.ObservableCollection<LayerViewModel>?)GetValue(AllMeshLayersProperty);
+            set => SetValue(AllMeshLayersProperty, value);
+        }
+
+        private static void OnAllMeshLayersChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is MeshEditorControl ctl && !ctl._isDisposed)
+            {
+                ctl.OnAllMeshLayersChanged((System.Collections.ObjectModel.ObservableCollection<LayerViewModel>?)e.OldValue, 
+                                          (System.Collections.ObjectModel.ObservableCollection<LayerViewModel>?)e.NewValue);
+            }
+        }
+
         private void OnSelectedLayerChanged(LayerViewModel? oldVm, LayerViewModel? newVm)
         {
             if (_isDisposed) return;
@@ -234,6 +261,85 @@ namespace ProjectionMapper.Views
             {
                 // fallback: show combined render host frame if available
                 SafeUpdateInputImageFromHost();
+            }
+        }
+
+        private void OnAllMeshLayersChanged(System.Collections.ObjectModel.ObservableCollection<LayerViewModel>? oldCollection, 
+                                          System.Collections.ObjectModel.ObservableCollection<LayerViewModel>? newCollection)
+        {
+            if (_isDisposed) return;
+
+            // Unsubscribe from old collection events
+            if (oldCollection != null)
+            {
+                oldCollection.CollectionChanged -= AllMeshLayers_CollectionChanged;
+                // Unsubscribe from property changes of individual layers
+                foreach (var layer in oldCollection)
+                {
+                    try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                }
+            }
+
+            // Subscribe to new collection events
+            if (newCollection != null)
+            {
+                newCollection.CollectionChanged += AllMeshLayers_CollectionChanged;
+                // Subscribe to property changes of individual layers
+                foreach (var layer in newCollection)
+                {
+                    try { layer.PropertyChanged += AllMeshLayer_PropertyChanged; } catch { }
+                }
+            }
+
+            // Refresh the display to show all mesh layer outlines
+            RefreshAllMeshLayerOverlays();
+        }
+
+        private void AllMeshLayers_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            if (_isDisposed) return;
+
+            // Handle added items
+            if (e.NewItems != null)
+            {
+                foreach (LayerViewModel layer in e.NewItems)
+                {
+                    try { layer.PropertyChanged += AllMeshLayer_PropertyChanged; } catch { }
+                }
+            }
+
+            // Handle removed items
+            if (e.OldItems != null)
+            {
+                foreach (LayerViewModel layer in e.OldItems)
+                {
+                    try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                }
+            }
+
+            // Refresh the display
+            RefreshAllMeshLayerOverlays();
+        }
+
+        private void AllMeshLayer_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (_isDisposed || _suppressVmRebind) return;
+
+            // Only refresh if mesh points changed for any layer
+            if (e == null || e.PropertyName == nameof(LayerViewModel.MeshPoints) || string.IsNullOrEmpty(e.PropertyName))
+            {
+                try 
+                { 
+                    if (!Dispatcher.CheckAccess())
+                    {
+                        Dispatcher.BeginInvoke(() => RefreshAllMeshLayerOverlays());
+                    }
+                    else
+                    {
+                        RefreshAllMeshLayerOverlays();
+                    }
+                } 
+                catch { }
             }
         }
 
@@ -498,7 +604,7 @@ namespace ProjectionMapper.Views
                 PART_OutputDrag.Width = _outputRect.Width;
                 PART_OutputDrag.Height = _outputRect.Height;
 
-                // If there's no selected layer, hide overlays and do not show any image
+                // If there's no selected layer, hide the selected layer's overlays
                 if (SelectedLayer == null)
                 {
                     PART_InputPolygon.Visibility = Visibility.Collapsed;
@@ -511,23 +617,160 @@ namespace ProjectionMapper.Views
 
                     // Do not show any preview image when nothing is selected
                     PART_InputImage.Source = null;
+                }
+                else
+                {
+                    // Show the selected layer's overlays with handles for editing
+                    PART_InputPolygon.Visibility = Visibility.Visible;
+                    PART_InputHandle_TL.Visibility = Visibility.Visible;
+                    PART_InputHandle_TR.Visibility = Visibility.Visible;
+                    PART_InputHandle_BL.Visibility = Visibility.Visible;
+                    PART_InputHandle_BR.Visibility = Visibility.Visible;
 
+                    // Hide output overlays in the input preview - output is shown in the output host
+                    PART_OutputRect.Visibility = Visibility.Collapsed;
+                    PART_OutputDrag.Visibility = Visibility.Collapsed;
+
+                    // If there's no isolated preview, fallback to bound host frame
+                    if (_videoService == null && _boundHost != null) PART_InputImage.Source = _boundHost.CurrentFrame;
+                }
+
+                // Also refresh all mesh layer overlays
+                RefreshAllMeshLayerOverlays();
+            }
+            catch { }
+        }
+
+        private void RefreshAllMeshLayerOverlays()
+        {
+            if (_isDisposed) return;
+
+            try
+            {
+                var cw = PART_Canvas.ActualWidth;
+                var ch = PART_Canvas.ActualHeight;
+                if (double.IsNaN(cw) || cw <= 0 || double.IsNaN(ch) || ch <= 0) return;
+
+                // Clear existing overlays
+                ClearAllMeshLayerOverlays();
+
+                // Create overlays for all mesh layers
+                if (AllMeshLayers != null)
+                {
+                    foreach (var layer in AllMeshLayers)
+                    {
+                        if (layer == null) continue;
+                        CreateOverlayForMeshLayer(layer, cw, ch);
+                    }
+                }
+            }
+            catch { }
+        }
+
+        private void ClearAllMeshLayerOverlays()
+        {
+            try
+            {
+                // Remove polygons from canvas
+                foreach (var polygon in _allMeshPolygons)
+                {
+                    try { PART_Canvas.Children.Remove(polygon); } catch { }
+                }
+                _allMeshPolygons.Clear();
+
+                // Remove handles from canvas
+                foreach (var (tl, tr, bl, br, _) in _allMeshHandles)
+                {
+                    try { PART_Canvas.Children.Remove(tl); } catch { }
+                    try { PART_Canvas.Children.Remove(tr); } catch { }
+                    try { PART_Canvas.Children.Remove(bl); } catch { }
+                    try { PART_Canvas.Children.Remove(br); } catch { }
+                }
+                _allMeshHandles.Clear();
+            }
+            catch { }
+        }
+
+        private void CreateOverlayForMeshLayer(LayerViewModel layer, double canvasWidth, double canvasHeight)
+        {
+            try
+            {
+                var pts = layer.MeshPoints;
+                if (pts == null || pts.Length < 4) return;
+
+                // Calculate corners
+                var corners = new Point[4];
+                corners[0] = new Point(pts[0].X * canvasWidth, pts[0].Y * canvasHeight); // TL
+                corners[1] = new Point(pts[1].X * canvasWidth, pts[1].Y * canvasHeight); // TR
+                corners[2] = new Point(pts[2].X * canvasWidth, pts[2].Y * canvasHeight); // BL
+                corners[3] = new Point(pts[3].X * canvasWidth, pts[3].Y * canvasHeight); // BR
+
+                // Determine if this is the selected layer to use different visual style
+                bool isSelected = layer == SelectedLayer;
+
+                // Create polygon
+                var polygon = new System.Windows.Shapes.Polygon
+                {
+                    Points = new System.Windows.Media.PointCollection { corners[0], corners[1], corners[3], corners[2] },
+                    Stroke = isSelected ? System.Windows.Media.Brushes.DodgerBlue : System.Windows.Media.Brushes.Orange,
+                    StrokeThickness = isSelected ? 2 : 1.5,
+                    Fill = isSelected ? new SolidColorBrush(Color.FromArgb(64, 52, 152, 219)) : new SolidColorBrush(Color.FromArgb(32, 255, 165, 0)),
+                    IsHitTestVisible = false // Don't interfere with mouse events
+                };
+
+                PART_Canvas.Children.Add(polygon);
+                _allMeshPolygons.Add(polygon);
+
+                // Only show handles for the selected layer (for editing)
+                if (isSelected)
+                {
+                    // The main polygon and handles are already handled by ApplyLayout for the selected layer
                     return;
                 }
 
-                // Otherwise display overlays
-                PART_InputPolygon.Visibility = Visibility.Visible;
-                PART_InputHandle_TL.Visibility = Visibility.Visible;
-                PART_InputHandle_TR.Visibility = Visibility.Visible;
-                PART_InputHandle_BL.Visibility = Visibility.Visible;
-                PART_InputHandle_BR.Visibility = Visibility.Visible;
+                // For non-selected layers, create small visual indicators only (no interactive handles)
+                var handleSize = 6.0;
+                var handleBrush = System.Windows.Media.Brushes.Orange;
+                
+                var tlIndicator = new System.Windows.Shapes.Ellipse
+                {
+                    Width = handleSize, Height = handleSize,
+                    Fill = handleBrush,
+                    IsHitTestVisible = false
+                };
+                Canvas.SetLeft(tlIndicator, corners[0].X - handleSize / 2);
+                Canvas.SetTop(tlIndicator, corners[0].Y - handleSize / 2);
+                PART_Canvas.Children.Add(tlIndicator);
 
-                // Hide output overlays in the input preview - output is shown in the output host
-                PART_OutputRect.Visibility = Visibility.Collapsed;
-                PART_OutputDrag.Visibility = Visibility.Collapsed;
+                var trIndicator = new System.Windows.Shapes.Ellipse
+                {
+                    Width = handleSize, Height = handleSize,
+                    Fill = handleBrush,
+                    IsHitTestVisible = false
+                };
+                Canvas.SetLeft(trIndicator, corners[1].X - handleSize / 2);
+                Canvas.SetTop(trIndicator, corners[1].Y - handleSize / 2);
+                PART_Canvas.Children.Add(trIndicator);
 
-                // If there's no isolated preview, fallback to bound host frame
-                if (_videoService == null && _boundHost != null) PART_InputImage.Source = _boundHost.CurrentFrame;
+                var blIndicator = new System.Windows.Shapes.Ellipse
+                {
+                    Width = handleSize, Height = handleSize,
+                    Fill = handleBrush,
+                    IsHitTestVisible = false
+                };
+                Canvas.SetLeft(blIndicator, corners[2].X - handleSize / 2);
+                Canvas.SetTop(blIndicator, corners[2].Y - handleSize / 2);
+                PART_Canvas.Children.Add(blIndicator);
+
+                var brIndicator = new System.Windows.Shapes.Ellipse
+                {
+                    Width = handleSize, Height = handleSize,
+                    Fill = handleBrush,
+                    IsHitTestVisible = false
+                };
+                Canvas.SetLeft(brIndicator, corners[3].X - handleSize / 2);
+                Canvas.SetTop(brIndicator, corners[3].Y - handleSize / 2);
+                PART_Canvas.Children.Add(brIndicator);
             }
             catch { }
         }
@@ -717,7 +960,23 @@ namespace ProjectionMapper.Views
         public void Dispose()
         {
             _isDisposed = true;
+            
+            // Clean up video service subscription
             if (_videoService != null && _frameHandler != null) _videoService.FrameDecoded -= _frameHandler;
+            
+            // Clean up all mesh layers subscription
+            if (AllMeshLayers != null)
+            {
+                AllMeshLayers.CollectionChanged -= AllMeshLayers_CollectionChanged;
+                foreach (var layer in AllMeshLayers)
+                {
+                    try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                }
+            }
+            
+            // Clear overlay elements
+            ClearAllMeshLayerOverlays();
+            
             _cts.Cancel();
             _cts.Dispose();
         }

--- a/Views/OutputMeshEditorControl.xaml
+++ b/Views/OutputMeshEditorControl.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              MinHeight="100" MinWidth="100">
     <Grid Background="Transparent">
-        <Canvas x:Name="PART_Canvas" Background="Transparent" IsHitTestVisible="True">
+        <Canvas x:Name="PART_Canvas" Background="Transparent" IsHitTestVisible="True" Width="1920" Height="1080">
             <!-- Live preview of the cropped frame for the selected mesh -->
             <Image x:Name="PART_CroppedPreview" Stretch="Fill" Visibility="Collapsed" IsHitTestVisible="False" />
 

--- a/Views/OutputMeshEditorControl.xaml.cs
+++ b/Views/OutputMeshEditorControl.xaml.cs
@@ -17,17 +17,21 @@ namespace ProjectionMapper.Views
 {
     public partial class OutputMeshEditorControl : UserControl, IDisposable
     {
+        // Track pending overlay retry attempts to avoid scheduling duplicates
+        private readonly System.Collections.Generic.HashSet<string> _overlayRetryPending = new();
+
         private LayerViewModel? _vm;
         private VideoService? _videoService;
         private bool _isDisposed = false;
 
         // corners in canvas coordinates: TL, TR, BL, BR
+        // Made 5% of original size: very small centered quad for easier initial placement
         private Point[] _corners = new Point[4]
         {
-            new Point(100,20),
-            new Point(420,20),
-            new Point(100,200),
-            new Point(420,200)
+            new Point(910, 505),  // TL - centered, 5% size (half of previous)
+            new Point(1010, 505), // TR
+            new Point(910, 575),  // BL
+            new Point(1010, 575)  // BR
         };
 
         private bool _suppressVmRebind = false;
@@ -77,12 +81,16 @@ namespace ProjectionMapper.Views
             if (oldVm != null)
             {
                 oldVm.PropertyChanged -= SelectedLayer_PropertyChanged;
-                // Clear the old layer from renderer
+                // Clear the old layer from renderer and remove its overlay
                 var layerId = oldVm.Model?.Id ?? oldVm.Id;
                 if (!string.IsNullOrEmpty(layerId))
                 {
                     // clear layer by submitting null frame; no destQuad -> null, opacity 0
                     RendererManager?.SubmitLayerFrame(layerId, null, new Rect(), null, 0.0);
+                    
+                    // Remove the mesh overlay for this layer
+                    var targetMonitor = oldVm.Model?.TargetMonitorIndex;
+                    try { RendererManager?.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layerId); } catch { }
                 }
             }
             if (newVm != null)
@@ -174,6 +182,279 @@ namespace ProjectionMapper.Views
         {
             get => (RendererManager?)GetValue(RendererManagerProperty);
             set => SetValue(RendererManagerProperty, value);
+        }
+
+        // Dependency property to expose all mesh layers collection so we can update all overlays
+        public static readonly DependencyProperty AllMeshLayersProperty = DependencyProperty.Register(
+            nameof(AllMeshLayers), typeof(System.Collections.ObjectModel.ObservableCollection<LayerViewModel>), typeof(OutputMeshEditorControl), new PropertyMetadata(null, OnAllMeshLayersChanged));
+
+        public System.Collections.ObjectModel.ObservableCollection<LayerViewModel>? AllMeshLayers
+        {
+            get => (System.Collections.ObjectModel.ObservableCollection<LayerViewModel>?)GetValue(AllMeshLayersProperty);
+            set => SetValue(AllMeshLayersProperty, value);
+        }
+
+        private static void OnAllMeshLayersChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is OutputMeshEditorControl ctl && !ctl._isDisposed)
+            {
+                ctl.OnAllMeshLayersChanged((System.Collections.ObjectModel.ObservableCollection<LayerViewModel>?)e.OldValue, 
+                                          (System.Collections.ObjectModel.ObservableCollection<LayerViewModel>?)e.NewValue);
+            }
+        }
+
+        private void OnAllMeshLayersChanged(System.Collections.ObjectModel.ObservableCollection<LayerViewModel>? oldCollection, 
+                                          System.Collections.ObjectModel.ObservableCollection<LayerViewModel>? newCollection)
+        {
+            if (_isDisposed) return;
+
+            // Unsubscribe from old collection events
+            if (oldCollection != null)
+            {
+                oldCollection.CollectionChanged -= AllMeshLayers_CollectionChanged;
+                // Unsubscribe from property changes of individual layers
+                foreach (var layer in oldCollection)
+                {
+                    try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                }
+            }
+
+            // Subscribe to new collection events
+            if (newCollection != null)
+            {
+                newCollection.CollectionChanged += AllMeshLayers_CollectionChanged;
+                // Subscribe to property changes of individual layers
+                foreach (var layer in newCollection)
+                {
+                    try { layer.PropertyChanged += AllMeshLayer_PropertyChanged; } catch { }
+                }
+                
+                // CRITICAL: Immediately update overlays for existing layers on initial binding
+                // This ensures overlays appear without requiring user interaction
+                foreach (var layer in newCollection)
+                {
+                    try
+                    {
+                        UpdateExternalOverlayForSingleLayer(layer);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"OutputMeshEditorControl: Initial overlay for {layer.Name} failed: {ex.Message}");
+                    }
+                }
+            }
+
+            // Also do a delayed update to catch any timing issues with renderer initialization
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                try
+                {
+                    if (_isDisposed) return;
+                    UpdateAllMeshLayersExternalOverlays();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"OutputMeshEditorControl: Delayed overlay update failed: {ex.Message}");
+                }
+            }), DispatcherPriority.Loaded);
+
+            Debug.WriteLine($"OutputMeshEditorControl: OnAllMeshLayersChanged: {newCollection?.Count ?? 0} layers");
+        }
+
+        private void AllMeshLayers_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            if (_isDisposed) return;
+
+            Debug.WriteLine($"OutputMeshEditorControl: AllMeshLayers_CollectionChanged: Action={e.Action}");
+
+            // Handle added items
+            if (e.NewItems != null)
+            {
+                foreach (LayerViewModel layer in e.NewItems)
+                {
+                    try { layer.PropertyChanged += AllMeshLayer_PropertyChanged; } catch { }
+                    Debug.WriteLine($"  OutputMeshEditorControl: Added layer: {layer.Name} (ID: {layer.Id})");
+                    
+                    // Immediately add overlay for the new layer
+                    UpdateExternalOverlayForSingleLayer(layer);
+                }
+            }
+
+            // Handle removed items
+            if (e.OldItems != null)
+            {
+                foreach (LayerViewModel layer in e.OldItems)
+                {
+                    try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                    Debug.WriteLine($"  OutputMeshEditorControl: Removed layer: {layer.Name} (ID: {layer.Id})");
+                    
+                    // Remove overlay for this layer
+                    if (layer?.Model?.Id != null && RendererManager != null)
+                    {
+                        var targetMonitor = layer.Model.TargetMonitorIndex;
+                        try 
+                        { 
+                            RendererManager.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layer.Model.Id); 
+                        } 
+                        catch { }
+                    }
+                }
+            }
+        }
+
+        private void AllMeshLayer_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (_isDisposed || _suppressVmRebind) return;
+
+            // Only update for specific property changes that affect overlays
+            if (e != null && !string.IsNullOrEmpty(e.PropertyName))
+            {
+                if (e.PropertyName == nameof(LayerViewModel.MeshPoints) || 
+                    e.PropertyName == nameof(LayerViewModel.OutputMeshPoints) ||
+                    e.PropertyName == nameof(LayerViewModel.ShowOverlay) ||
+                    e.PropertyName == nameof(LayerViewModel.Visible))
+                {
+                    // Update only the specific layer that changed, not all layers
+                    if (sender is LayerViewModel changedLayer)
+                    {
+                        try 
+                        { 
+                            if (!Dispatcher.CheckAccess())
+                            {
+                                Dispatcher.BeginInvoke(() => UpdateExternalOverlayForSingleLayer(changedLayer), DispatcherPriority.Normal);
+                            }
+                            else
+                            {
+                                UpdateExternalOverlayForSingleLayer(changedLayer);
+                            }
+                        } 
+                        catch { }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Update external overlay for a single layer (efficient, targeted update).
+        /// </summary>
+        private void UpdateExternalOverlayForSingleLayer(LayerViewModel meshVm)
+        {
+            if (_isDisposed || meshVm?.Model == null || RendererManager == null) return;
+
+            try
+            {
+                var layerId = meshVm.Model.Id;
+                if (string.IsNullOrEmpty(layerId)) return;
+
+                var showOverlayPref = meshVm.Model.ShowOverlay;
+                if (!showOverlayPref)
+                {
+                    // Remove overlay if disabled
+                    var targetMonitor = meshVm.Model.TargetMonitorIndex;
+                    try 
+                    { 
+                        RendererManager.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layerId); 
+                    } 
+                    catch { }
+                    return;
+                }
+
+                var targetMonitor2 = meshVm.Model.TargetMonitorIndex;
+
+                // Choose which mesh points to use: OutputMeshPoints if customized, else MeshPoints
+                Vector2[]? meshPointsToUse = null;
+                var outputPts = meshVm.OutputMeshPoints;
+                var inputPts = meshVm.MeshPoints;
+
+                // Check if OutputMeshPoints are at defaults
+                bool outputPtsAreDefault = (outputPts != null && outputPts.Length >= 4 &&
+                    IsPointApproximately(outputPts[0], new System.Numerics.Vector2(0f, 0f)) &&
+                    IsPointApproximately(outputPts[1], new System.Numerics.Vector2(1f, 0f)) &&
+                    IsPointApproximately(outputPts[2], new System.Numerics.Vector2(0f, 1f)) &&
+                    IsPointApproximately(outputPts[3], new System.Numerics.Vector2(1f, 1f)));
+
+                meshPointsToUse = outputPtsAreDefault ? inputPts : outputPts;
+
+                // Map to renderer coordinates
+                Point[]? quadForRenderer = null;
+                try
+                {
+                    quadForRenderer = RendererManager.MapNormalizedToRendererPoints(meshPointsToUse, targetMonitor2 >= 0 ? targetMonitor2 : null);
+                }
+                catch { quadForRenderer = null; }
+
+                if (quadForRenderer != null && quadForRenderer.Length >= 4)
+                {
+                    // Remove existing overlay and add new one
+                    try { RendererManager.RemoveMeshOverlayForMonitor(targetMonitor2 >= 0 ? targetMonitor2 : null, layerId); } catch { }
+                    try { RendererManager.AddMeshOverlayForMonitor(targetMonitor2 >= 0 ? targetMonitor2 : null, quadForRenderer, true, layerId); } catch { }
+
+                    // If we had a pending retry scheduled, clear it since we succeeded
+                    try { lock (_overlayRetryPending) { _overlayRetryPending.Remove(layerId); } } catch { }
+                }
+                else
+                {
+                    // If mapping failed (renderer not yet ready / no frame), try host-based fallback if available
+                    bool didFallback = false;
+                    try
+                    {
+                        if (HostRenderHost != null)
+                        {
+                            var cf = HostRenderHost.CurrentFrame;
+                            if (cf != null && cf.PixelWidth > 0 && cf.PixelHeight > 0 && PART_Canvas.ActualWidth > 0 && PART_Canvas.ActualHeight > 0)
+                            {
+                                var scaleX = cf.PixelWidth / PART_Canvas.ActualWidth;
+                                var scaleY = cf.PixelHeight / PART_Canvas.ActualHeight;
+                                var fallbackQuad = new Point[4]
+                                {
+                                    new Point(meshVm.OutputMeshPoints[0].X * PART_Canvas.ActualWidth * scaleX, meshVm.OutputMeshPoints[0].Y * PART_Canvas.ActualHeight * scaleY),
+                                    new Point(meshVm.OutputMeshPoints[1].X * PART_Canvas.ActualWidth * scaleX, meshVm.OutputMeshPoints[1].Y * PART_Canvas.ActualHeight * scaleY),
+                                    new Point(meshVm.OutputMeshPoints[2].X * PART_Canvas.ActualWidth * scaleX, meshVm.OutputMeshPoints[2].Y * PART_Canvas.ActualHeight * scaleY),
+                                    new Point(meshVm.OutputMeshPoints[3].X * PART_Canvas.ActualWidth * scaleX, meshVm.OutputMeshPoints[3].Y * PART_Canvas.ActualHeight * scaleY)
+                                };
+
+                                try { RendererManager.RemoveMeshOverlayForMonitor(targetMonitor2 >= 0 ? targetMonitor2 : null, layerId); } catch { }
+                                try { RendererManager.AddMeshOverlayForMonitor(targetMonitor2 >= 0 ? targetMonitor2 : null, fallbackQuad, true, layerId); } catch { }
+                                didFallback = true;
+                            }
+                        }
+                    }
+                    catch { didFallback = false; }
+
+                    // If we neither mapped nor fell back, schedule a one-time retry when renderer/host is likely ready
+                    if (!didFallback)
+                    {
+                        bool alreadyScheduled = false;
+                        try { lock (_overlayRetryPending) { alreadyScheduled = !_overlayRetryPending.Add(layerId); } } catch { alreadyScheduled = true; }
+                        if (!alreadyScheduled)
+                        {
+                            try
+                            {
+                                // schedule background retry - won't block UI
+                                Dispatcher.BeginInvoke(new Action(async () =>
+                                {
+                                    try
+                                    {
+                                        await Task.Delay(250).ConfigureAwait(false);
+                                    }
+                                    catch { }
+                                    try
+                                    {
+                                        if (_isDisposed) return;
+                                        UpdateExternalOverlayForSingleLayer(meshVm);
+                                    }
+                                    catch { }
+                                }), DispatcherPriority.Background);
+                            }
+                            catch { }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"UpdateExternalOverlayForSingleLayer: Failed for {meshVm.Name}: {ex.Message}");
+            }
         }
 
         private void VideoService_FrameDecoded(string layerId, BitmapSource? bmp)
@@ -521,7 +802,7 @@ namespace ProjectionMapper.Views
                                         {
                                             try
                                             {
-                                                RendererManager.SetMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, quadForRenderer, showPoints);
+                                                RendererManager.AddMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, quadForRenderer, showPoints, layerId);
                                             }
                                             catch { }
                                         }
@@ -547,7 +828,7 @@ namespace ProjectionMapper.Views
                                                         new Point(_corners[2].X * scaleX, _corners[2].Y * scaleY),
                                                         new Point(_corners[3].X * scaleX, _corners[3].Y * scaleY)
                                                     };
-                                                    try { HostRenderHost.SetMeshOverlay(fallbackQuad, showPoints); } catch { }
+                                                    try { HostRenderHost.AddMeshOverlay(fallbackQuad, showPoints); } catch { }
                                                 }
                                                 catch { }
                                             }
@@ -561,8 +842,39 @@ namespace ProjectionMapper.Views
                         catch (Exception exGlobal) { Debug.WriteLine($"WriteBackMeshPoints global failure: {exGlobal}"); }
                     }
                 }
+
+                // CRITICAL FIX: Update ALL mesh layers' external overlays after editing ANY mesh point
+                // This ensures all mesh layers show their overlays in real-time, not just the selected one
+                UpdateAllMeshLayersExternalOverlays();
             }
             catch (Exception ex) { Debug.WriteLine($"WriteBackMeshPoints top-level error: {ex}"); }
+        }
+
+        /// <summary>
+        /// Update external overlays for ALL mesh layers in real-time.
+        /// This is called after editing any mesh point to ensure all overlays remain visible and positioned correctly.
+        /// </summary>
+        private void UpdateAllMeshLayersExternalOverlays()
+        {
+            if (AllMeshLayers == null || RendererManager == null) return;
+
+            try
+            {
+                foreach (var meshVm in AllMeshLayers)
+                {
+                    if (meshVm?.Model == null) continue;
+                    UpdateExternalOverlayForSingleLayer(meshVm);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"UpdateAllMeshLayersExternalOverlays: Failed: {ex.Message}");
+            }
+        }
+
+        private static bool IsPointApproximately(System.Numerics.Vector2 point, System.Numerics.Vector2 target, float tolerance = 0.01f)
+        {
+            return Math.Abs(point.X - target.X) < tolerance && Math.Abs(point.Y - target.Y) < tolerance;
         }
 
         private void MapSelectedLayerMeshToRects()
@@ -621,6 +933,16 @@ namespace ProjectionMapper.Views
         {
             _isDisposed = true;
             if (_videoService != null) try { _videoService.FrameDecoded -= VideoService_FrameDecoded; } catch { }
+            
+            // Clean up all mesh layers subscription
+            if (AllMeshLayers != null)
+            {
+                AllMeshLayers.CollectionChanged -= AllMeshLayers_CollectionChanged;
+                foreach (var layer in AllMeshLayers)
+                {
+                    try { layer.PropertyChanged -= AllMeshLayer_PropertyChanged; } catch { }
+                }
+            }
         }
 
         private BitmapSource? WarpBitmap(BitmapSource? source, Point[] quadPoints, Rect destRect)

--- a/Views/OutputMeshEditorControl.xaml.cs
+++ b/Views/OutputMeshEditorControl.xaml.cs
@@ -323,6 +323,7 @@ namespace ProjectionMapper.Views
                 figure.Segments.Add(new LineSegment(new Point(_corners[1].X - minX, _corners[1].Y - minY), true));
                 figure.Segments.Add(new LineSegment(new Point(_corners[3].X - minX, _corners[3].Y - minY), true));
                 figure.Segments.Add(new LineSegment(new Point(_corners[2].X - minX, _corners[2].Y - minY), true));
+                figure.IsClosed = true;
                 clipGeometry.Figures.Add(figure);
                 PART_CroppedPreview.Clip = clipGeometry;
 
@@ -443,33 +444,52 @@ namespace ProjectionMapper.Views
                             Point[]? destQuad = null;
                             try
                             {
-                                if (HostRenderHost != null && HostRenderHost.CurrentFrame != null && PART_Canvas.ActualWidth > 0 && PART_Canvas.ActualHeight > 0)
-                                {
-                                    var scaleX = HostRenderHost.CurrentFrame.PixelWidth / PART_Canvas.ActualWidth;
-                                    var scaleY = HostRenderHost.CurrentFrame.PixelHeight / PART_Canvas.ActualHeight;
+                                // Try to map normalized output points to renderer pixel coordinates via RendererManager
+                                destQuad = RendererManager?.MapNormalizedToRendererPoints(_vm.OutputMeshPoints, _vm.Model?.TargetMonitorIndex);
+                            }
+                            catch (Exception exQuad) { Debug.WriteLine($"WriteBackMeshPoints: MapNormalizedToRendererPoints failed: {exQuad}"); destQuad = null; }
 
-                                    destQuad = new Point[4]
-                                    {
-                                        new Point(_corners[0].X * scaleX, _corners[0].Y * scaleY), // TL
-                                        new Point(_corners[1].X * scaleX, _corners[1].Y * scaleY), // TR
-                                        new Point(_corners[2].X * scaleX, _corners[2].Y * scaleY), // BL
-                                        new Point(_corners[3].X * scaleX, _corners[3].Y * scaleY)  // BR
-                                    };
-                                }
-                                else
+                            // If mapping failed (no main host frame available), fall back to host-based mapping using HostRenderHost
+                            if (destQuad == null)
+                            {
+                                if (HostRenderHost != null)
                                 {
-                                    destQuad = new Point[4]
+                                    try
                                     {
-                                        new Point(_corners[0].X, _corners[0].Y), // TL
-                                        new Point(_corners[1].X, _corners[1].Y), // TR
-                                        new Point(_corners[2].X, _corners[2].Y), // BL
-                                        new Point(_corners[3].X, _corners[3].Y)  // BR
-                                    };
+                                        var cf = HostRenderHost.CurrentFrame;
+                                        if (cf != null && cf.PixelWidth > 0 && cf.PixelHeight > 0 && PART_Canvas.ActualWidth > 0 && PART_Canvas.ActualHeight > 0)
+                                        {
+                                            var scaleX = cf.PixelWidth / PART_Canvas.ActualWidth;
+                                            var scaleY = cf.PixelHeight / PART_Canvas.ActualHeight;
+                                            destQuad = new Point[4]
+                                            {
+                                                new Point(_corners[0].X * scaleX, _corners[0].Y * scaleY),
+                                                new Point(_corners[1].X * scaleX, _corners[1].Y * scaleY),
+                                                new Point(_corners[2].X * scaleX, _corners[2].Y * scaleY),
+                                                new Point(_corners[3].X * scaleX, _corners[3].Y * scaleY)
+                                            };
+                                        }
+                                    }
+                                    catch { destQuad = null; }
                                 }
                             }
-                            catch (Exception exQuad) { Debug.WriteLine($"WriteBackMeshPoints: create destQuad failed: {exQuad}"); destQuad = null; }
 
                             var destRect = new Rect(_vm.X, _vm.Y, Math.Max(1, _vm.Width), Math.Max(1, _vm.Height));
+                            // clamp destQuad to renderer bounds if possible
+                            try
+                            {
+                                if (destQuad != null && RendererManager != null && RendererManager.OutputWidth > 0 && RendererManager.OutputHeight > 0)
+                                {
+                                    for (int i = 0; i < destQuad.Length; ++i)
+                                    {
+                                        var p = destQuad[i];
+                                        p.X = Math.Max(0, Math.Min(RendererManager.OutputWidth, p.X));
+                                        p.Y = Math.Max(0, Math.Min(RendererManager.OutputHeight, p.Y));
+                                        destQuad[i] = p;
+                                    }
+                                }
+                            }
+                            catch { }
                             try
                             {
                                 // Pass destQuad to RendererManager; it will pass through to the renderer which will warp if supported.

--- a/Views/OutputMeshEditorControl.xaml.cs
+++ b/Views/OutputMeshEditorControl.xaml.cs
@@ -474,6 +474,67 @@ namespace ProjectionMapper.Views
                             {
                                 // Pass destQuad to RendererManager; it will pass through to the renderer which will warp if supported.
                                 RendererManager.SubmitLayerFrame(layerId, frameToSubmit, destRect, destQuad, _vm.Opacity);
+
+                                // Also instruct RendererManager to show the mesh overlay on the output host/fullscreen for this layer
+                                try
+                                {
+                                    bool showPoints = true;
+                                    // respect per-layer preference if present
+                                    var targetMonitor = _vm.Model?.TargetMonitorIndex;
+                                    var showOverlayPref = _vm.Model?.ShowOverlay ?? true;
+                                    if (!showOverlayPref || RendererManager == null)
+                                    {
+                                        // clear overlay on host if disabled
+                                        try { HostRenderHost?.ClearOverlay(); } catch { }
+                                    }
+                                    else
+                                    {
+                                        // Map normalized output mesh points to renderer coordinates
+                                        Point[]? quadForRenderer = null;
+                                        try
+                                        {
+                                            quadForRenderer = RendererManager?.MapNormalizedToRendererPoints(_vm.OutputMeshPoints, targetMonitor);
+                                        }
+                                        catch { quadForRenderer = null; }
+
+                                        if (quadForRenderer != null && quadForRenderer.Length >= 4)
+                                        {
+                                            try
+                                            {
+                                                RendererManager.SetMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, quadForRenderer, showPoints);
+                                            }
+                                            catch { }
+                                        }
+                                        else
+                                        {
+                                            // fallback to host-based mapping using HostRenderHost current frame
+                                            if (HostRenderHost != null)
+                                            {
+                                                try
+                                                {
+                                                    var scaleX = 1.0;
+                                                    var scaleY = 1.0;
+                                                    var cf = HostRenderHost.CurrentFrame;
+                                                    if (cf != null && cf.PixelWidth > 0 && cf.PixelHeight > 0 && PART_Canvas.ActualWidth > 0 && PART_Canvas.ActualHeight > 0)
+                                                    {
+                                                        scaleX = cf.PixelWidth / PART_Canvas.ActualWidth;
+                                                        scaleY = cf.PixelHeight / PART_Canvas.ActualHeight;
+                                                    }
+                                                    var fallbackQuad = new Point[4]
+                                                    {
+                                                        new Point(_corners[0].X * scaleX, _corners[0].Y * scaleY),
+                                                        new Point(_corners[1].X * scaleX, _corners[1].Y * scaleY),
+                                                        new Point(_corners[2].X * scaleX, _corners[2].Y * scaleY),
+                                                        new Point(_corners[3].X * scaleX, _corners[3].Y * scaleY)
+                                                    };
+                                                    try { HostRenderHost.SetMeshOverlay(fallbackQuad, showPoints); } catch { }
+                                                }
+                                                catch { }
+                                            }
+                                        }
+                                    }
+                                }
+                                catch { }
                             }
                             catch (Exception exSubmit) { Debug.WriteLine($"WriteBackMeshPoints: SubmitLayerFrame failed: {exSubmit}"); }
                         }

--- a/Views/RenderHostControl.xaml
+++ b/Views/RenderHostControl.xaml
@@ -10,5 +10,7 @@
     -->
     <Grid Background="Black">
         <Image x:Name="PART_Backbuffer" Stretch="Uniform" SnapsToDevicePixels="True" />
+        <!-- Overlay canvas drawn on top of the backbuffer. All visuals here are non-interactive and used for mesh preview outlines. -->
+        <Canvas x:Name="PART_Overlay" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
     </Grid>
 </UserControl>

--- a/Views/RenderHostControl.xaml.cs
+++ b/Views/RenderHostControl.xaml.cs
@@ -129,7 +129,7 @@ namespace ProjectionMapper.Views
         /// <summary>
         /// Set a bitmap frame produced by the renderer (BitmapSource must be frozen).
         /// This method is safe to call from the UI thread; calls from background threads will be dispatched.
-        /// </summary>
+        /// </summary)
         public void SetFrame(BitmapSource frame)
         {
             if (_disposed) return;
@@ -197,6 +197,7 @@ namespace ProjectionMapper.Views
         /// <summary>
         /// Draw a quad outline and optional points on the overlay canvas.
         /// Coordinates are in renderer pixel space and will be mapped to overlay size which matches control actual size.
+        /// This method clears existing mesh overlays and draws only this one - use AddMeshOverlay for multiple overlays.
         /// </summary>
         public void SetMeshOverlay(System.Windows.Point[]? quadPoints, bool showPoints)
         {
@@ -207,7 +208,26 @@ namespace ProjectionMapper.Views
                 return;
             }
 
-            PART_Overlay.Children.Clear();
+            // Clear only mesh overlays, preserve grid overlays
+            ClearMeshOverlay();
+            
+            if (quadPoints == null || quadPoints.Length < 4) return;
+
+            AddMeshOverlay(quadPoints, showPoints);
+        }
+
+        /// <summary>
+        /// Add a mesh overlay without clearing existing ones. Allows multiple quad outlines to be displayed simultaneously.
+        /// </summary>
+        public void AddMeshOverlay(System.Windows.Point[]? quadPoints, bool showPoints)
+        {
+            if (_disposed) return;
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(() => AddMeshOverlay(quadPoints, showPoints));
+                return;
+            }
+
             if (quadPoints == null || quadPoints.Length < 4) return;
 
             try
@@ -269,6 +289,9 @@ namespace ProjectionMapper.Views
                         PART_Overlay.Children.Add(ellipse);
                     }
                 }
+
+                // Force redraw of the overlay canvas
+                PART_Overlay.InvalidateVisual();
             }
             catch { }
         }

--- a/Views/RenderHostControl.xaml.cs
+++ b/Views/RenderHostControl.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 namespace ProjectionMapper.Views
@@ -79,6 +80,93 @@ namespace ProjectionMapper.Views
                     CurrentFrame = null;
                 });
             }
+        }
+
+        /// <summary>
+        /// Clear any overlay visuals (quad outline/points).
+        /// </summary>
+        public void ClearOverlay()
+        {
+            if (_disposed) return;
+            if (Dispatcher.CheckAccess()) PART_Overlay.Children.Clear();
+            else Dispatcher.Invoke(() => PART_Overlay.Children.Clear());
+        }
+
+        /// <summary>
+        /// Draw a quad outline and optional points on the overlay canvas.
+        /// Coordinates are in renderer pixel space and will be mapped to overlay size which matches control actual size.
+        /// </summary>
+        public void SetMeshOverlay(System.Windows.Point[]? quadPoints, bool showPoints)
+        {
+            if (_disposed) return;
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(() => SetMeshOverlay(quadPoints, showPoints));
+                return;
+            }
+
+            PART_Overlay.Children.Clear();
+            if (quadPoints == null || quadPoints.Length < 4) return;
+
+            try
+            {
+                // Map source renderer pixel coordinates to overlay control coordinates
+                double scaleX = 1.0, scaleY = 1.0;
+                try
+                {
+                    // prefer mapping using the actual current frame pixel size -> overlay size
+                    if (CurrentFrame != null && CurrentFrame.PixelWidth > 0 && CurrentFrame.PixelHeight > 0 && PART_Overlay.ActualWidth > 0 && PART_Overlay.ActualHeight > 0)
+                    {
+                        scaleX = PART_Overlay.ActualWidth / CurrentFrame.PixelWidth;
+                        scaleY = PART_Overlay.ActualHeight / CurrentFrame.PixelHeight;
+                    }
+                    else if (PART_Backbuffer.ActualWidth > 0 && PART_Backbuffer.ActualHeight > 0 && CurrentFrame != null && CurrentFrame.PixelWidth > 0 && CurrentFrame.PixelHeight > 0)
+                    {
+                        scaleX = PART_Backbuffer.ActualWidth / CurrentFrame.PixelWidth;
+                        scaleY = PART_Backbuffer.ActualHeight / CurrentFrame.PixelHeight;
+                    }
+                }
+                catch { }
+
+                // Draw outline
+                var poly = new System.Windows.Shapes.Polygon
+                {
+                    Stroke = System.Windows.Media.Brushes.White,
+                    StrokeThickness = 3,
+                    Fill = System.Windows.Media.Brushes.Transparent,
+                    IsHitTestVisible = false
+                };
+                var pts = new PointCollection
+                {
+                    new System.Windows.Point(quadPoints[0].X * scaleX, quadPoints[0].Y * scaleY),
+                    new System.Windows.Point(quadPoints[1].X * scaleX, quadPoints[1].Y * scaleY),
+                    new System.Windows.Point(quadPoints[3].X * scaleX, quadPoints[3].Y * scaleY),
+                    new System.Windows.Point(quadPoints[2].X * scaleX, quadPoints[2].Y * scaleY)
+                };
+                poly.Points = pts;
+                PART_Overlay.Children.Add(poly);
+
+                if (showPoints)
+                {
+                    // draw red points at each corner
+                    for (int i = 0; i < 4; i++)
+                    {
+                        var ellipse = new System.Windows.Shapes.Ellipse
+                        {
+                            Width = 12,
+                            Height = 12,
+                            Fill = System.Windows.Media.Brushes.Red,
+                            Stroke = System.Windows.Media.Brushes.Black,
+                            StrokeThickness = 1,
+                            IsHitTestVisible = false
+                        };
+                        Canvas.SetLeft(ellipse, quadPoints[i].X * scaleX - 6);
+                        Canvas.SetTop(ellipse, quadPoints[i].Y * scaleY - 6);
+                        PART_Overlay.Children.Add(ellipse);
+                    }
+                }
+            }
+            catch { }
         }
 
         public void Dispose()

--- a/Views/RenderHostControl.xaml.cs
+++ b/Views/RenderHostControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Diagnostics;
 
 namespace ProjectionMapper.Views
 {
@@ -13,6 +14,107 @@ namespace ProjectionMapper.Views
         public RenderHostControl()
         {
             InitializeComponent();
+        }
+
+        /// <summary>
+        /// Draw a coordinate grid on the overlay canvas mapped from renderer pixel coordinates.
+        /// spacingPixels: spacing between grid lines in renderer pixel coordinates.
+        /// Labels are drawn with the renderer pixel coordinate values for X and Y.
+        /// </summary>
+        public void SetCoordinateGrid(int spacingPixels)
+        {
+            if (_disposed) return;
+            if (spacingPixels <= 0) return;
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(() => SetCoordinateGrid(spacingPixels));
+                return;
+            }
+
+            PART_Overlay.Children.Clear();
+
+            try
+            {
+                // Need renderer pixel size to map coordinates
+                if (CurrentFrame == null || CurrentFrame.PixelWidth <= 0 || CurrentFrame.PixelHeight <= 0) return;
+
+                double overlayW = PART_Overlay.ActualWidth <= 0 ? PART_Backbuffer.ActualWidth : PART_Overlay.ActualWidth;
+                double overlayH = PART_Overlay.ActualHeight <= 0 ? PART_Backbuffer.ActualHeight : PART_Overlay.ActualHeight;
+                if (overlayW <= 0 || overlayH <= 0) return;
+
+                double scaleX = overlayW / CurrentFrame.PixelWidth;
+                double scaleY = overlayH / CurrentFrame.PixelHeight;
+
+                var lineBrush = new SolidColorBrush(Color.FromArgb(0x88, 0xFF, 0xFF, 0xFF));
+                lineBrush.Freeze();
+
+                var textBrush = new SolidColorBrush(Colors.White);
+                textBrush.Freeze();
+
+                // Vertical lines and labels (X)
+                for (int x = 0; x <= CurrentFrame.PixelWidth; x += spacingPixels)
+                {
+                    double sx = x * scaleX;
+                    var line = new System.Windows.Shapes.Line
+                    {
+                        X1 = sx,
+                        Y1 = 0,
+                        X2 = sx,
+                        Y2 = overlayH,
+                        Stroke = lineBrush,
+                        StrokeThickness = 1,
+                        IsHitTestVisible = false
+                    };
+                    line.Tag = "Grid";
+                    PART_Overlay.Children.Add(line);
+
+                    var tb = new TextBlock
+                    {
+                        Text = x.ToString(),
+                        Foreground = textBrush,
+                        FontSize = 12,
+                        IsHitTestVisible = false
+                    };
+                    tb.Tag = "Grid";
+                    Canvas.SetLeft(tb, Math.Max(0, sx + 2));
+                    Canvas.SetTop(tb, 2);
+                    PART_Overlay.Children.Add(tb);
+                }
+
+                // Horizontal lines and labels (Y)
+                for (int y = 0; y <= CurrentFrame.PixelHeight; y += spacingPixels)
+                {
+                    double sy = y * scaleY;
+                    var line = new System.Windows.Shapes.Line
+                    {
+                        X1 = 0,
+                        Y1 = sy,
+                        X2 = overlayW,
+                        Y2 = sy,
+                        Stroke = lineBrush,
+                        StrokeThickness = 1,
+                        IsHitTestVisible = false
+                    };
+                    line.Tag = "Grid";
+                    PART_Overlay.Children.Add(line);
+
+                    var tb = new TextBlock
+                    {
+                        Text = y.ToString(),
+                        Foreground = textBrush,
+                        FontSize = 12,
+                        IsHitTestVisible = false
+                    };
+                    tb.Tag = "Grid";
+                    Canvas.SetLeft(tb, 2);
+                    Canvas.SetTop(tb, Math.Max(0, sy + 2));
+                    PART_Overlay.Children.Add(tb);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"SetCoordinateGrid failed: {ex}");
+            }
         }
 
         public static readonly DependencyProperty CurrentFrameProperty = DependencyProperty.Register(
@@ -136,6 +238,7 @@ namespace ProjectionMapper.Views
                     Fill = System.Windows.Media.Brushes.Transparent,
                     IsHitTestVisible = false
                 };
+                poly.Tag = "Mesh";
                 var pts = new PointCollection
                 {
                     new System.Windows.Point(quadPoints[0].X * scaleX, quadPoints[0].Y * scaleY),
@@ -162,8 +265,45 @@ namespace ProjectionMapper.Views
                         };
                         Canvas.SetLeft(ellipse, quadPoints[i].X * scaleX - 6);
                         Canvas.SetTop(ellipse, quadPoints[i].Y * scaleY - 6);
+                        ellipse.Tag = "Mesh";
                         PART_Overlay.Children.Add(ellipse);
                     }
+                }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Remove any grid elements previously drawn on the overlay.
+        /// </summary>
+        public void ClearGridOverlay()
+        {
+            if (_disposed) return;
+            if (!Dispatcher.CheckAccess()) { Dispatcher.Invoke(() => ClearGridOverlay()); return; }
+            try
+            {
+                for (int i = PART_Overlay.Children.Count - 1; i >= 0; --i)
+                {
+                    var child = PART_Overlay.Children[i] as FrameworkElement;
+                    if (child != null && child.Tag is string t && t == "Grid") PART_Overlay.Children.RemoveAt(i);
+                }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Remove any mesh overlay elements previously drawn on the overlay.
+        /// </summary>
+        public void ClearMeshOverlay()
+        {
+            if (_disposed) return;
+            if (!Dispatcher.CheckAccess()) { Dispatcher.Invoke(() => ClearMeshOverlay()); return; }
+            try
+            {
+                for (int i = PART_Overlay.Children.Count - 1; i >= 0; --i)
+                {
+                    var child = PART_Overlay.Children[i] as FrameworkElement;
+                    if (child != null && child.Tag is string t && t == "Mesh") PART_Overlay.Children.RemoveAt(i);
                 }
             }
             catch { }


### PR DESCRIPTION
1.	When a new mesh layer is created, it now inherits the selected imported video’s monitor assignment (if set). That ensures overlays/frames are targeted to the same fullscreen host immediately.
2.	After registering a new mesh, the code now forces the current composed frame from the main output host to be pushed to the fullscreen host for the mesh’s target monitor (if any). This gives the fullscreen host an initial frame and helps the overlay mapping be available immediately for newly-created meshes.