### PR TITLE
Fixed looping, pause/resume and audio artifacts in FFmpegUnifiedDecoder

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-```json
-{
-  "servers": {
-    "github": {
-      "url": "https://api.githubcopilot.com/mcp/"
-    }
-  }
-}
-```

--- a/Services/FFmpegUnifiedDecoder.cs
+++ b/Services/FFmpegUnifiedDecoder.cs
@@ -20,13 +20,13 @@ namespace ProjectionMapper.Services
         private readonly string _inputPath;
         private readonly int _width;
         private readonly int _height;
-  private readonly string? _ffmpegPath;
+        private readonly string? _ffmpegPath;
         private Process? _process;
-    private CancellationTokenSource? _cts;
+        private CancellationTokenSource? _cts;
 
         // Audio components
         private IWavePlayer? _wavePlayer;
-    private BufferedWaveProvider? _waveProvider;
+        private BufferedWaveProvider? _waveProvider;
         private readonly WaveFormat _audioFormat = new(44100, 16, 2); // 44.1kHz, 16-bit, stereo
 
         // Video events
@@ -35,442 +35,690 @@ namespace ProjectionMapper.Services
 
         // Audio control properties
         private bool _audioEnabled = false;
-    private float _volume = 1.0f;
- private bool _muted = false;
+        private float _volume = 1.0f;
+        private bool _muted = false;
 
-     /// <summary>
- /// When true, the decoder will automatically restart when EOF is reached.
-        /// </summary>
-        public bool Loop { get; set; }
+        // Position tracking for pause/resume with loop support
+        private TimeSpan _currentPosition = TimeSpan.Zero;
+      private Stopwatch? _playbackTimer;
+        private readonly object _positionLock = new();
+        
+        // Video duration for loop-aware position tracking
+        private TimeSpan _videoDuration = TimeSpan.Zero;
 
         /// <summary>
-      /// When true, audio will be decoded and played. When false, audio is muted but still decoded for sync.
+        /// When true, the decoder will automatically restart when EOF is reached.
+      /// </summary>
+      public bool Loop { get; set; }
+
+        /// <summary>
+        /// When true, audio will be decoded and played. When false, audio is muted but still decoded for sync.
         /// </summary>
         public bool AudioEnabled
-      {
-    get => _audioEnabled;
+        {
+            get => _audioEnabled;
             set
-    {
-     _audioEnabled = value;
-       UpdateAudioPlayback();
+            {
+                _audioEnabled = value;
+                UpdateAudioPlayback();
             }
-    }
+        }
 
         /// <summary>
-      /// Audio volume (0.0 - 1.0).
+        /// Audio volume (0.0 - 1.0).
         /// </summary>
         public float Volume
         {
             get => _volume;
-       set
-        {
-        _volume = Math.Max(0f, Math.Min(1f, value));
-  UpdateAudioPlayback();
+            set
+            {
+                _volume = Math.Max(0f, Math.Min(1f, value));
+                UpdateAudioPlayback();
             }
-      }
+        }
 
-     /// <summary>
+        /// <summary>
         /// When true, audio output is muted (but still decoded for sync).
         /// </summary>
-   public bool Muted
+        public bool Muted
         {
-     get => _muted;
-       set
-    {
-   _muted = value;
-  UpdateAudioPlayback();
+            get => _muted;
+            set
+            {
+                _muted = value;
+                UpdateAudioPlayback();
             }
- }
+        }
 
-      // Captured frames-per-second parsed from ffmpeg stderr (0 = unknown)
-  private double _capturedFps = 0.0;
+        /// <summary>
+        /// Current playback position (read-only).
+        /// </summary>
+        public TimeSpan CurrentPosition
+        {
+            get
+            {
+                lock (_positionLock)
+                {
+                    if (_playbackTimer != null && _playbackTimer.IsRunning)
+                    {
+                        return _currentPosition + _playbackTimer.Elapsed;
+                    }
+                    return _currentPosition;
+                }
+            }
+        }
 
-   public FFmpegUnifiedDecoder(string inputPath, int width, int height, string? ffmpegPath = null)
+        /// <summary>
+        /// Save current position and stop the playback timer.
+        /// </summary>
+        public void SaveCurrentPosition()
+        {
+            lock (_positionLock)
+            {
+                if (_playbackTimer != null && _playbackTimer.IsRunning)
+                {
+                    _currentPosition += _playbackTimer.Elapsed;
+                    _playbackTimer.Stop();
+                    _playbackTimer = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set the position to resume from.
+        /// </summary>
+        public void SetResumePosition(TimeSpan position)
+        {
+            lock (_positionLock)
+            {
+                _currentPosition = position;
+            }
+        }
+
+        // Captured frames-per-second parsed from ffmpeg stderr (0 = unknown)
+        private double _capturedFps = 0.0;
+
+        public FFmpegUnifiedDecoder(string inputPath, int width, int height, string? ffmpegPath = null)
         {
             _inputPath = inputPath ?? throw new ArgumentNullException(nameof(inputPath));
-   _width = Math.Max(1, width);
-_height = Math.Max(1, height);
+            _width = Math.Max(1, width);
+            _height = Math.Max(1, height);
             _ffmpegPath = string.IsNullOrEmpty(ffmpegPath) ? "ffmpeg" : ffmpegPath;
         }
 
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
-          if (_process != null) throw new InvalidOperationException("Decoder already started.");
+            if (_process != null) throw new InvalidOperationException("Decoder already started.");
 
-      _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            // CRITICAL: Probe video duration for loop-aware position tracking
+  try
+            {
+     var duration = TryProbeDuration(_inputPath, _ffmpegPath);
+       if (duration > TimeSpan.Zero)
+     {
+    _videoDuration = duration;
+      Debug.WriteLine($"FFmpegUnifiedDecoder: Video duration detected: {duration.TotalSeconds:F2}s");
+           }
+      else
+ {
+        Debug.WriteLine("FFmpegUnifiedDecoder: Could not detect video duration - loop position tracking may be inaccurate");
+ }
+        }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"FFmpegUnifiedDecoder: Duration probe failed: {ex}");
+            }
 
             // Try to probe framerate up-front
-     try
-    {
-              var fps = TryProbeFps(_inputPath, _ffmpegPath);
-             if (fps > 0) Interlocked.Exchange(ref _capturedFps, fps);
-     }
-            catch { }
-
-            // Initialize audio components
-            InitializeAudio();
-
-            try
+      try
             {
-    do
-      {
-          if (_cts.IsCancellationRequested) break;
+          var fps = TryProbeFps(_inputPath, _ffmpegPath);
+  if (fps > 0) Interlocked.Exchange(ref _capturedFps, fps);
+          }
+          catch { }
 
-     await StartSingleDecodingSession();
+         // Initialize audio components
+         InitializeAudio();
 
-            // If not looping, exit
-        if (!Loop) break;
+            // Start playback timer
+     lock (_positionLock)
+            {
+ _playbackTimer = Stopwatch.StartNew();
+         }
 
-      // Small delay before restarting
-        await Task.Delay(100, _cts.Token).ConfigureAwait(false);
+       try
+            {
+       do
+   {
+       if (_cts.IsCancellationRequested) break;
 
-                } while (!_cts.Token.IsCancellationRequested);
+        await StartSingleDecodingSession();
+
+   // If not looping, exit
+     if (!Loop) break;
+
+   // CRITICAL: Reset position to 0 for next loop iteration
+       lock (_positionLock)
+       {
+         _currentPosition = TimeSpan.Zero;
+           if (_playbackTimer != null)
+           {
+           _playbackTimer.Restart();
+          }
+  Debug.WriteLine("FFmpegUnifiedDecoder: Loop iteration complete, position reset to 0");
        }
-            finally
-            {
-         CleanupProcess();
+
+   // Small delay before restarting
+     await Task.Delay(100, _cts.Token).ConfigureAwait(false);
+
+          } while (!_cts.Token.IsCancellationRequested);
+ }
+     finally
+      {
+         // Save position before cleanup
+        lock (_positionLock)
+    {
+if (_playbackTimer != null)
+         {
+              _currentPosition += _playbackTimer.Elapsed;
+            _playbackTimer.Stop();
+              _playbackTimer = null;
+      }
+    }
+
+           CleanupProcess();
             }
         }
 
-     private async Task StartSingleDecodingSession()
- {
-// Use FFmpeg to output video to stdout as raw BGRA frames
-            // Use -re for real-time playback to maintain natural timing
-  string loopArg = Loop ? "-stream_loop -1" : "";
-   var videoArgs = $"-hide_banner -loglevel info {loopArg} -re -i \"{_inputPath}\" " +
-         $"-f rawvideo -pix_fmt bgra -vf scale={_width}:{_height} -an pipe:1";
+    private async Task StartSingleDecodingSession()
+        {
+         // Get current seek position
+            TimeSpan seekPos;
+            lock (_positionLock)
+            {
+       seekPos = _currentPosition;
+           
+       // CRITICAL: Clamp seek position to video duration to prevent seeking past end
+             if (_videoDuration > TimeSpan.Zero && seekPos >= _videoDuration)
+       {
+           seekPos = TimeSpan.Zero;
+               _currentPosition = TimeSpan.Zero;
+   if (_playbackTimer != null)
+   {
+ _playbackTimer.Restart();
+     }
+              Debug.WriteLine("FFmpegUnifiedDecoder: Seek position clamped to 0 (was >= duration)");
+            }
+            }
 
-   var psi = new ProcessStartInfo
-  {
-          FileName = _ffmpegPath!,
-       Arguments = videoArgs,
-          UseShellExecute = false,
-     RedirectStandardOutput = true,
-   RedirectStandardError = true,
-     CreateNoWindow = true
-            };
+            // CRITICAL: Clear audio buffer at start of each session to prevent loop artifacts
+    if (_waveProvider != null)
+      {
+  try
+      {
+     _waveProvider.ClearBuffer();
+    Debug.WriteLine("FFmpegUnifiedDecoder.StartSingleDecodingSession: Cleared audio buffer to prevent loop artifacts");
+       }
+      catch (Exception ex)
+       {
+   Debug.WriteLine($"FFmpegUnifiedDecoder.StartSingleDecodingSession: Failed to clear buffer: {ex}");
+      }
+   }
 
-            _process = Process.Start(psi);
- if (_process == null) throw new InvalidOperationException("Failed to start ffmpeg process.");
+        // Use FFmpeg to output video to stdout as raw BGRA frames
+         // Use -re for real-time playback to maintain natural timing
+            // NOTE: We do NOT use -stream_loop because it breaks position tracking
+  // Instead we handle looping ourselves by restarting the process
+            string seekArg = seekPos.TotalSeconds > 0.1 ? $"-ss {seekPos.TotalSeconds:F3}" : "";
+  var videoArgs = $"-hide_banner -loglevel info {seekArg} -re -i \"{_inputPath}\" " +
+     $"-f rawvideo -pix_fmt bgra -vf scale={_width}:{_height} -an pipe:1";
 
-     // Start separate FFmpeg process for audio (synchronized using -re)
-            var audioTask = StartAudioDecoding();
+var psi = new ProcessStartInfo
+    {
+  FileName = _ffmpegPath!,
+        Arguments = videoArgs,
+ UseShellExecute = false,
+        RedirectStandardOutput = true,
+                RedirectStandardError = true,
+         CreateNoWindow = true
+   };
 
-       // Start stderr reading for FPS detection
-        var stderrTask = Task.Run(() => ReadStderr(_process.StandardError, _cts.Token), _cts.Token);
+    _process = Process.Start(psi);
+            if (_process == null) throw new InvalidOperationException("Failed to start ffmpeg process.");
+
+       // Start separate FFmpeg process for audio (synchronized using -re)
+     var audioTask = StartAudioDecoding(seekPos);
+
+            // Start stderr reading for FPS detection
+     var stderrTask = Task.Run(() => ReadStderr(_process.StandardError, _cts.Token), _cts.Token);
 
             try
-          {
-    // Read video frames from stdout
+            {
+            // Read video frames from stdout
      await ReadVideoFrames(_process.StandardOutput.BaseStream!, _cts.Token);
- }
-  finally
-            {
-       CleanupProcess();
-    
-                // Wait for tasks to complete
-        try { await audioTask; } catch { }
-    try { await stderrTask; } catch { }
-          }
-        }
+            }
+     finally
+  {
+     CleanupProcess();
 
-        private async Task StartAudioDecoding()
+  // Wait for tasks to complete
+ try { await audioTask; } catch { }
+ try { await stderrTask; } catch { }
+  }
+     }
+
+   private async Task StartAudioDecoding(TimeSpan seekPosition)
         {
-  try
-            {
- // Create separate FFmpeg process for audio that runs in sync with video
-   string loopArg = Loop ? "-stream_loop -1" : "";
-     var audioArgs = $"-hide_banner -loglevel error {loopArg} -re -i \"{_inputPath}\" " +
-          $"-f s16le -acodec pcm_s16le -ac 2 -ar 44100 -vn pipe:1";
+   try
+  {
+        // Create separate FFmpeg process for audio that runs in sync with video
+      // NOTE: We do NOT use -stream_loop here either
+    string seekArg = seekPosition.TotalSeconds > 0.1 ? $"-ss {seekPosition.TotalSeconds:F3}" : "";
+     var audioArgs = $"-hide_banner -loglevel error {seekArg} -re -i \"{_inputPath}\" " +
+                 $"-f s16le -acodec pcm_s16le -ac 2 -ar 44100 -vn pipe:1";
 
-        var audioPsi = new ProcessStartInfo
-            {
+       var audioPsi = new ProcessStartInfo
+    {
     FileName = _ffmpegPath!,
   Arguments = audioArgs,
-         UseShellExecute = false,
+ UseShellExecute = false,
     RedirectStandardOutput = true,
    RedirectStandardError = false,
-   CreateNoWindow = true
-      };
+ CreateNoWindow = true
+ };
 
-                using var audioProcess = Process.Start(audioPsi);
+       using var audioProcess = Process.Start(audioPsi);
        if (audioProcess == null) return;
 
-             var buffer = new byte[8192];
+var buffer = new byte[8192];
     var audioStream = audioProcess.StandardOutput.BaseStream;
 
      while (!_cts.Token.IsCancellationRequested && !audioProcess.HasExited)
         {
    try
        {
-             var bytesRead = await audioStream.ReadAsync(buffer, 0, buffer.Length, _cts.Token);
+   var bytesRead = await audioStream.ReadAsync(buffer, 0, buffer.Length, _cts.Token);
       
-    if (bytesRead > 0 && _waveProvider != null)
+ if (bytesRead > 0 && _waveProvider != null)
    {
-             try
+         try
     {
 _waveProvider.AddSamples(buffer, 0, bytesRead);
-       }
-          catch (Exception ex)
+
+      // CRITICAL: Auto-start playback when buffer has enough data
+            // This runs in the decode loop thread, ensuring perfect timing
+  if (_audioEnabled && _wavePlayer is WaveOutEvent waveOut && 
+     waveOut.PlaybackState != PlaybackState.Playing && 
+   _waveProvider.BufferedBytes > 8192) // Wait for at least ~185ms of audio buffered
          {
-        Debug.WriteLine($"FFmpegUnifiedDecoder: Audio buffer add failed: {ex}");
+ try
+   {
+       waveOut.Play();
+   Debug.WriteLine($"FFmpegUnifiedDecoder.StartAudioDecoding: Auto-started playback (buffer has {_waveProvider.BufferedBytes} bytes)");
+       }
+      catch (Exception ex)
+       {
+         Debug.WriteLine($"FFmpegUnifiedDecoder.StartAudioDecoding: Auto-start failed: {ex}");
+       }
+       }
+       }
+   catch (Exception ex)
+ {
+  Debug.WriteLine($"FFmpegUnifiedDecoder: Audio buffer add failed: {ex}");
     }
            }
    else if (bytesRead == 0)
     {
-  // EOF or no data, small delay
-await Task.Delay(10, _cts.Token);
-               }
+  // EOF reached - exit cleanly to allow restart
+      Debug.WriteLine("FFmpegUnifiedDecoder.StartAudioDecoding: Audio EOF reached");
+       break;
+ }
   }
         catch (OperationCanceledException) { break; }
-              catch (Exception ex)
-   {
-        Debug.WriteLine($"FFmpegUnifiedDecoder: Audio read error: {ex}");
-               await Task.Delay(50, _cts.Token);
-         }
+       catch (Exception ex)
+ {
+ Debug.WriteLine($"FFmpegUnifiedDecoder: Audio read error: {ex}");
+   await Task.Delay(50, _cts.Token);
+ }
      }
 
-         // Clean up audio process
+       // Clean up audio process
  try
-                {
+       {
    if (!audioProcess.HasExited)
 {
        audioProcess.Kill(true);
        }
       }
-         catch { }
-      }
-            catch (Exception ex)
+ catch { }
+    }
+  catch (Exception ex)
   {
-             Debug.WriteLine($"FFmpegUnifiedDecoder: Audio decoding failed: {ex}");
+        Debug.WriteLine($"FFmpegUnifiedDecoder: Audio decoding failed: {ex}");
          }
         }
 
-        private async Task ReadVideoFrames(Stream stdout, CancellationToken cancellationToken)
+   private async Task ReadVideoFrames(Stream stdout, CancellationToken cancellationToken)
         {
-    var frameSize = _width * _height * 4;
-var buffer = new byte[frameSize];
-            var sw = Stopwatch.StartNew();
+            var frameSize = _width * _height * 4;
+            var buffer = new byte[frameSize];
+         var sw = Stopwatch.StartNew();
 
-     try
+      try
+      {
+       while (!cancellationToken.IsCancellationRequested)
+      {
+      int read = 0;
+        while (read < frameSize)
+   {
+     var chunk = await stdout.ReadAsync(buffer, read, frameSize - read, cancellationToken).ConfigureAwait(false);
+              if (chunk == 0) 
     {
-   while (!cancellationToken.IsCancellationRequested)
-    {
-              int read = 0;
-         while (read < frameSize)
-           {
-    var chunk = await stdout.ReadAsync(buffer, read, frameSize - read, cancellationToken).ConfigureAwait(false);
-    if (chunk == 0) return; // EOF
-     read += chunk;
+    // EOF reached - return to allow outer loop to restart if Loop is enabled
+     return;
+       }
+       read += chunk;
   }
 
-        if (read < frameSize) return; // EOF reached
+  if (read < frameSize) 
+   {
+      // Incomplete frame read - likely at EOF
+       return;
+   }
 
-      // Create BitmapSource from buffer (BGRA32)
- var stride = _width * 4;
-   var bmp = BitmapSource.Create(_width, _height, 96, 96, PixelFormats.Bgra32, null, buffer, stride);
-        bmp.Freeze();
+    // Create BitmapSource from buffer (BGRA32)
+    var stride = _width * 4;
+          var bmp = BitmapSource.Create(_width, _height, 96, 96, PixelFormats.Bgra32, null, buffer, stride);
+         bmp.Freeze();
 
-            // Compute presentation timestamp
-          var pts = sw.Elapsed;
+          // Compute presentation timestamp
+    var pts = sw.Elapsed;
 
- // Deliver frame events
-    FrameDecoded?.Invoke(bmp);
-               FrameDecodedWithTimestamp?.Invoke(bmp, pts);
+    // Deliver frame events
+         FrameDecoded?.Invoke(bmp);
+             FrameDecodedWithTimestamp?.Invoke(bmp, pts);
 
-        // Note: We rely on FFmpeg's -re flag for pacing, so no additional throttling needed
-    }
-      }
-    catch (OperationCanceledException) { }
-            catch (Exception ex)
-          {
-            Debug.WriteLine($"FFmpegUnifiedDecoder: Video reading failed: {ex}");
-       }
-        }
+          // Note: We rely on FFmpeg's -re flag for pacing, so no additional throttling needed
+            }
+         }
+  catch (OperationCanceledException) { }
+         catch (Exception ex)
+         {
+                Debug.WriteLine($"FFmpegUnifiedDecoder: Video reading failed: {ex}");
+            }
+  }
 
         private async Task ReadStderr(StreamReader stderr, CancellationToken cancellationToken)
         {
             try
- {
-      var re = new Regex(@"(?<fps>\d+(?:\.\d+)?)\s+fps", RegexOptions.Compiled);
-     while (!cancellationToken.IsCancellationRequested && !stderr.EndOfStream)
-                {
-           var line = await stderr.ReadLineAsync().ConfigureAwait(false);
-    if (string.IsNullOrEmpty(line)) continue;
-
-         // Try to parse fps
-      try
-    {
-             var m = re.Match(line);
-          if (m.Success && double.TryParse(m.Groups["fps"].Value, out var fps) && fps > 0)
             {
-       Interlocked.Exchange(ref _capturedFps, fps);
-     }
+                // Null check to prevent NullReferenceException on restart
+                if (stderr == null) return;
+
+                var re = new Regex(@"(?<fps>\d+(?:\.\d+)?)\s+fps", RegexOptions.Compiled);
+                while (!cancellationToken.IsCancellationRequested && !stderr.EndOfStream)
+                {
+                    var line = await stderr.ReadLineAsync().ConfigureAwait(false);
+                    if (string.IsNullOrEmpty(line)) continue;
+
+                    // Try to parse fps
+                    try
+                    {
+                        var m = re.Match(line);
+                        if (m.Success && double.TryParse(m.Groups["fps"].Value, out var fps) && fps > 0)
+                        {
+                            Interlocked.Exchange(ref _capturedFps, fps);
+                        }
+                    }
+                    catch { }
+                }
             }
-       catch { }
-    }
-      }
-   catch (OperationCanceledException) { }
+            catch (OperationCanceledException) { }
             catch { }
         }
 
         private void InitializeAudio()
         {
-       try
-          {
-        // Create wave provider with buffer
-          _waveProvider = new BufferedWaveProvider(_audioFormat)
-           {
-BufferDuration = TimeSpan.FromMilliseconds(750),
-        DiscardOnBufferOverflow = true,
-ReadFully = true
-              };
-
-         // Create wave player
-   _wavePlayer = new WaveOutEvent
-   {
-              DesiredLatency = 120,
-  NumberOfBuffers = 3
-   };
-
-    _wavePlayer.Init(_waveProvider);
-  UpdateAudioPlayback();
-
-                // Always start playback - we'll control volume/muting
-       _wavePlayer.Play();
-        }
-  catch (Exception ex)
+            try
             {
-   Debug.WriteLine($"FFmpegUnifiedDecoder: Audio initialization failed: {ex}");
+                // Create wave provider with buffer
+                _waveProvider = new BufferedWaveProvider(_audioFormat)
+                {
+                    BufferDuration = TimeSpan.FromMilliseconds(750),
+                    DiscardOnBufferOverflow = true,
+                    ReadFully = true
+                };
+
+                // Create wave player
+                _wavePlayer = new WaveOutEvent
+                {
+                    DesiredLatency = 120,
+                    NumberOfBuffers = 3
+                };
+
+                _wavePlayer.Init(_waveProvider);
+                UpdateAudioPlayback();
+
+                // CRITICAL: Only start playback if audio is already enabled
+                // Otherwise, let the decode loop auto-start when buffer has data
+                if (_audioEnabled)
+                {
+                    _wavePlayer.Play();
+                    Debug.WriteLine($"FFmpegUnifiedDecoder: Started playback immediately, AudioEnabled={_audioEnabled}");
+                }
+                else
+                {
+                    Debug.WriteLine($"FFmpegUnifiedDecoder: Playback NOT started (AudioEnabled={_audioEnabled}), will auto-start when enabled");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"FFmpegUnifiedDecoder: Audio initialization failed: {ex}");
             }
         }
 
         private void UpdateAudioPlayback()
- {
-          if (_wavePlayer is WaveOutEvent waveOut)
-      {
-            try
-          {
-           if (_audioEnabled && !_muted)
         {
-               waveOut.Volume = _volume;
-        }
-        else
-   {
-        waveOut.Volume = 0f;
-       }
+            if (_wavePlayer is WaveOutEvent waveOut)
+            {
+                try
+                {
+                    if (_audioEnabled && !_muted)
+                    {
+                        // Clear buffer to prevent stale audio artifacts
+                        if (_waveProvider != null)
+                        {
+                            try
+                            {
+                                _waveProvider.ClearBuffer();
+                                Debug.WriteLine("FFmpegUnifiedDecoder.UpdateAudioPlayback: Cleared audio buffer to prevent artifacts");
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine($"FFmpegUnifiedDecoder.UpdateAudioPlayback: Failed to clear buffer: {ex}");
+                            }
+                        }
+
+                        waveOut.Volume = _volume;
+
+                        // Note: Playback will auto-start from decode loop once buffer fills
+                        // We don't call Play() here to avoid race conditions with empty buffer
+                        Debug.WriteLine($"FFmpegUnifiedDecoder.UpdateAudioPlayback: Audio ENABLED, volume={_volume}, playback will auto-start once buffer fills");
+                        Debug.WriteLine($"FFmpegUnifiedDecoder.UpdateAudioPlayback: WaveOut PlaybackState={waveOut.PlaybackState}");
+                    }
+                    else
+                    {
+                        waveOut.Volume = 0f;
+
+                        // Stop playback when disabling audio
+                        if (waveOut.PlaybackState == PlaybackState.Playing)
+                        {
+                            try
+                            {
+                                waveOut.Stop();
+                                Debug.WriteLine("FFmpegUnifiedDecoder.UpdateAudioPlayback: Stopped WaveOut playback");
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine($"FFmpegUnifiedDecoder.UpdateAudioPlayback: Failed to stop playback: {ex}");
+                            }
+                        }
+
+                        Debug.WriteLine("FFmpegUnifiedDecoder.UpdateAudioPlayback: Audio DISABLED (volume = 0)");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"FFmpegUnifiedDecoder: Audio update failed: {ex}");
+                }
             }
-    catch (Exception ex)
-         {
-     Debug.WriteLine($"FFmpegUnifiedDecoder: Audio update failed: {ex}");
-   }
+            else
+            {
+                Debug.WriteLine("FFmpegUnifiedDecoder.UpdateAudioPlayback: _wavePlayer is not WaveOutEvent or is null");
+            }
         }
+
+        private static TimeSpan TryProbeDuration(string path, string? ffmpegPath)
+        {
+   try
+         {
+    // Use ffprobe to get duration
+       var ffprobe = (ffmpegPath ?? "ffmpeg").Replace("ffmpeg", "ffprobe");
+         var psi = new ProcessStartInfo
+       {
+         FileName = ffprobe,
+                    Arguments = $"-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"{path}\"",
+            UseShellExecute = false,
+     RedirectStandardOutput = true,
+   RedirectStandardError = true,
+   CreateNoWindow = true
+        };
+
+      using var proc = Process.Start(psi);
+         if (proc != null)
+                {
+           var output = proc.StandardOutput.ReadToEnd();
+         proc.WaitForExit(1000);
+ if (!string.IsNullOrEmpty(output))
+     {
+      var durationStr = output.Trim();
+       if (double.TryParse(durationStr, out var durationSeconds) && durationSeconds > 0)
+           {
+   return TimeSpan.FromSeconds(durationSeconds);
+              }
+           }
+  }
+    }
+         catch { }
+
+       return TimeSpan.Zero;
         }
 
         private static double TryProbeFps(string path, string? ffmpegPath)
-        {
-        try
-            {
-        // Try ffprobe first
-                var ffprobe = (ffmpegPath ?? "ffmpeg").Replace("ffmpeg", "ffprobe");
-  var psi = new ProcessStartInfo
-         {
-      FileName = ffprobe,
-     Arguments = $"-v error -select_streams v:0 -show_entries stream=r_frame_rate -of default=noprint_wrappers=1:nokey=1 \"{path}\"",
-        UseShellExecute = false,
-          RedirectStandardOutput = true,
-     RedirectStandardError = true,
-  CreateNoWindow = true
+      {
+   try
+          {
+            // Try ffprobe first
+         var ffprobe = (ffmpegPath ?? "ffmpeg").Replace("ffmpeg", "ffprobe");
+              var psi = new ProcessStartInfo
+       {
+        FileName = ffprobe,
+       Arguments = $"-v error -select_streams v:0 -show_entries stream=r_frame_rate -of default=noprint_wrappers=1:nokey=1 \"{path}\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+    RedirectStandardError = true,
+   CreateNoWindow = true
     };
 
-                using var proc = Process.Start(psi);
-    if (proc != null)
- {
-    var outp = proc.StandardOutput.ReadToEnd();
-  proc.WaitForExit(1000);
-          if (!string.IsNullOrEmpty(outp))
-    {
-            var txt = outp.Trim();
-             if (txt.Contains('/'))
-              {
-         var parts = txt.Split('/');
-                    if (parts.Length == 2 && double.TryParse(parts[0], out var num) && double.TryParse(parts[1], out var den) && den != 0)
+     using var proc = Process.Start(psi);
+      if (proc != null)
+      {
+       var outp = proc.StandardOutput.ReadToEnd();
+        proc.WaitForExit(1000);
+         if (!string.IsNullOrEmpty(outp))
         {
-           return num / den;
+    var txt = outp.Trim();
+   if (txt.Contains('/'))
+           {
+        var parts = txt.Split('/');
+              if (parts.Length == 2 && double.TryParse(parts[0], out var numer) && double.TryParse(parts[1], out var denom) && denom > 0)
+     {
+   return Math.Round(numer / denom, 4);
+              }
+  }
+    else if (double.TryParse(txt, out var fps) && fps > 0)
+        {
+  return Math.Round(fps, 4);
+       }
+  }
  }
-        }
-        else if (double.TryParse(txt, out var v))
-   {
-        return v;
-      }
-             }
-       }
-     }
-      catch { }
-
-         // Fallback: try to parse FPS from ffmpeg -i output
-      try
-            {
-      var psi2 = new ProcessStartInfo
-              {
-       FileName = ffmpegPath ?? "ffmpeg",
-            Arguments = $"-hide_banner -i \"{path}\"",
-     UseShellExecute = false,
-       RedirectStandardError = true,
-              RedirectStandardOutput = true,
- CreateNoWindow = true
-       };
-    using var proc2 = Process.Start(psi2);
-      if (proc2 != null)
-         {
-         var err = proc2.StandardError.ReadToEnd();
-          proc2.WaitForExit(1000);
-        if (!string.IsNullOrEmpty(err))
-        {
-  var re = new Regex(@"(?<fps>\d+(?:\.\d+)?)\s+fps", RegexOptions.Compiled);
-   var m = re.Match(err);
-              if (m.Success && double.TryParse(m.Groups["fps"].Value, out var fps) && fps > 0) return fps;
-       }
-   }
             }
-       catch { }
+            catch { }
 
-            return 0.0;
-   }
+          return 0.0;
+  }
 
    private void CleanupProcess()
         {
-            try
-   {
-      if (_process != null && !_process.HasExited)
-      {
-     try { _process.Kill(true); } catch { }
-      }
-    }
-            catch { }
-
-          try { _process?.Dispose(); } catch { }
-            _process = null;
-        }
-
-  public void Stop()
+  try
     {
-            try
-            {
-       _cts?.Cancel();
-            }
-          catch { }
+                if (_process != null)
+                {
+       try
+          {
+             if (!_process.HasExited)
+     {
+   // Send SIGTERM first (graceful exit)
+   _process.Kill();
+          _process.WaitForExit(1000);
+             }
         }
+          catch { }
+
+      _process.Dispose();
+            _process = null;
+     }
+      }
+         catch (Exception ex)
+            {
+      Debug.WriteLine($"FFmpegUnifiedDecoder: Process cleanup failed: {ex}");
+      }
+ }
 
         public void Dispose()
         {
-      Stop();
+       // Stop any ongoing decoding
+            _cts?.Cancel();
 
-      try { _wavePlayer?.Stop(); } catch { }
- try { _wavePlayer?.Dispose(); } catch { }
-            try { _cts?.Dispose(); } catch { }
+            // Wait briefly to allow tasks to observe cancellation
+        try { Thread.Sleep(50); } catch { }
 
-     CleanupProcess();
-  }
+  // Final cleanup
+ CleanupProcess();
+
+   // Dispose audio components
+            try
+         {
+          if (_wavePlayer != null)
+       {
+  _wavePlayer.Stop();
+        _wavePlayer.Dispose();
+   _wavePlayer = null;
+          }
+     }
+  catch { }
+
+         try
+       {
+     if (_waveProvider != null)
+     {
+ _waveProvider.ClearBuffer();
+       _waveProvider = null;
+       }
+            }
+   catch { }
+        }
     }
 }

--- a/Services/VideoService.cs
+++ b/Services/VideoService.cs
@@ -10,656 +10,771 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using ProjectionMapper.Models;
 using ProjectionMapper.Rendering;
+using System.Numerics;
 
 namespace ProjectionMapper.Services
 {
-    /// <summary>
-    /// VideoService manages FFmpegUnifiedDecoder instances for synchronized video and audio playback per layer.
-    /// Implements frame forwarding to the renderer with unified audio/video synchronization.
-    /// </summary>
-    public sealed class VideoService : IVideoService, IDisposable
-    {
-        private readonly RendererManager _rendererManager;
+ /// <summary>
+ /// VideoService manages FFmpegUnifiedDecoder instances for synchronized video and audio playback per layer.
+ /// Implements frame forwarding to the renderer with unified audio/video synchronization.
+ /// </summary>
+ public sealed class VideoService : IVideoService, IDisposable
+ {
+ private readonly RendererManager _rendererManager;
 
-        // LayerId -> (decoder, cts, model, lastFrame)
-        private readonly ConcurrentDictionary<string, (FFmpegUnifiedDecoder? decoder, CancellationTokenSource? cts, LayerModel model, BitmapSource? lastFrame)> _decoders
-            = new();
+ // LayerId -> (decoder, cts, model, lastFrame, isPaused, savedPosition)
+ private readonly ConcurrentDictionary<string, (FFmpegUnifiedDecoder? decoder, CancellationTokenSource? cts, LayerModel model, BitmapSource? lastFrame, bool isPaused, TimeSpan savedPosition)> _decoders
+ = new();
 
-      // mesh layers that reference host sources: meshId -> LayerModel
-   private readonly ConcurrentDictionary<string, LayerModel> _meshLayers = new();
+ // mesh layers that reference host sources: meshId -> LayerModel
+ private readonly ConcurrentDictionary<string, LayerModel> _meshLayers = new();
 
-        // last forwarded frame timestamp per layer used for throttling/coalescing FrameDecoded events
-  private readonly ConcurrentDictionary<string, DateTime> _lastFrameSent = new();
+ // last forwarded frame timestamp per layer used for throttling/coalescing FrameDecoded events
+ private readonly ConcurrentDictionary<string, DateTime> _lastFrameSent = new();
 
-        // minimum interval between FrameDecoded events forwarded to subscribers (throttle)
-        private readonly TimeSpan _minFrameInterval = TimeSpan.FromMilliseconds(33); // ~30 fps by default
+ // minimum interval between FrameDecoded events forwarded to subscribers (throttle)
+ private readonly TimeSpan _minFrameInterval = TimeSpan.FromMilliseconds(33); // ~30 fps by default
 
-      private readonly string? _ffmpegPath;
+ private readonly string? _ffmpegPath;
 
-        public VideoService(RendererManager rendererManager, string? ffmpegPath = null)
-    {
-         _rendererManager = rendererManager ?? throw new ArgumentNullException(nameof(rendererManager));
-            _ffmpegPath = ffmpegPath;
-        }
+ public VideoService(RendererManager rendererManager, string? ffmpegPath = null)
+ {
+ _rendererManager = rendererManager ?? throw new ArgumentNullException(nameof(rendererManager));
+ _ffmpegPath = ffmpegPath;
+ }
 
-      /// <summary>
-        /// Event raised when a decoder produces a new frame for a layer. Parameters: layerId, frozen BitmapSource (may be null).
-        /// Note: events are throttled per-layer to reduce UI spam; consumers can call TryGetLastFrame to read the latest cached frame.
-        /// </summary>
-        public event Action<string, BitmapSource?>? FrameDecoded;
+ /// <summary>
+ /// Event raised when a decoder produces a new frame for a layer. Parameters: layerId, frozen BitmapSource (may be null).
+ /// Note: events are throttled per-layer to reduce UI spam; consumers can call TryGetLastFrame to read the latest cached frame.
+ /// </summary>
+ public event Action<string, BitmapSource?>? FrameDecoded;
 
-        private void InvokeOnUi(Action action)
-        {
-   try
-      {
-       var app = Application.Current;
-       if (app == null || app.Dispatcher == null || app.Dispatcher.HasShutdownStarted || app.Dispatcher.HasShutdownFinished)
-      {
-           // fallback: run inline
-        try { action(); } catch { }
-}
-          else
-          {
-   app.Dispatcher.BeginInvoke((Action)(() => { try { action(); } catch { } }));
-           }
-            }
-  catch { try { action(); } catch { } }
-     }
+ private void InvokeOnUi(Action action)
+ {
+ try
+ {
+ var app = Application.Current;
+ if (app == null || app.Dispatcher == null || app.Dispatcher.HasShutdownStarted || app.Dispatcher.HasShutdownFinished)
+ {
+ // fallback: run inline
+ try { action(); } catch { }
+ }
+ else
+ {
+ app.Dispatcher.BeginInvoke((Action)(() => { try { action(); } catch { } }));
+ }
+ }
+ catch { try { action(); } catch { } }
+ }
 
-        public Task<bool> RegisterLayerAsync(LayerModel layer)
-        {
-            return RegisterLayerAsync(layer, playAudio: false);
-        }
+ public Task<bool> RegisterLayerAsync(LayerModel layer) => RegisterLayerAsync(layer, playAudio: false);
 
-        public async Task<bool> RegisterLayerAsync(LayerModel layer, bool playAudio = false)
-        {
-            if (layer == null) throw new ArgumentNullException(nameof(layer));
-            if (string.IsNullOrWhiteSpace(layer.SourcePath)) return false;
-    if (!File.Exists(layer.SourcePath)) throw new FileNotFoundException("Source video not found", layer.SourcePath);
+ public async Task<bool> RegisterLayerAsync(LayerModel layer, bool playAudio = false)
+ {
+ if (layer == null) throw new ArgumentNullException(nameof(layer));
+ if (string.IsNullOrWhiteSpace(layer.SourcePath)) return false;
+ if (!File.Exists(layer.SourcePath)) throw new FileNotFoundException("Source video not found", layer.SourcePath);
 
-    string ffmpegExecutable = ResolveFfmpegExecutable();
+ string ffmpegExecutable = ResolveFfmpegExecutable();
 
-      var w = Math.Max(1, layer.Width > 0 ? layer.Width : 640);
- var h = Math.Max(1, layer.Height > 0 ? layer.Height : 480);
+ var w = Math.Max(1, layer.Width >0 ? layer.Width :640);
+ var h = Math.Max(1, layer.Height >0 ? layer.Height :480);
 
-     // Ensure a stable key and keep model updated
-  var layerKey = layer.Id ?? Guid.NewGuid().ToString("N");
+ // Ensure a stable key and keep model updated
+ var layerKey = layer.Id ?? Guid.NewGuid().ToString("N");
 
-   // If a decoder already exists for this layer, DO NOT create another one (prevents flicker/race).
-  // Just update the model and handle audio toggle.
-            if (_decoders.TryGetValue(layerKey, out var existing) && existing.decoder != null && existing.cts != null)
-            {
-     try
-{
-       _decoders[layerKey] = (existing.decoder, existing.cts, layer, existing.lastFrame);
-       
-     // Update audio settings on existing decoder
-           existing.decoder.AudioEnabled = playAudio || layer.PlayAudio;
-         existing.decoder.Volume = (float)Math.Max(0.0, Math.Min(1.0, layer.Volume));
-          existing.decoder.Muted = layer.Muted;
-       }
-                catch { }
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Registering layer {layerKey} (playAudio: {playAudio})");
 
-                return true;
-    }
+ // If a decoder already exists for this layer, update model and audio settings if active
+ if (_decoders.TryGetValue(layerKey, out var existing) && existing.decoder != null && existing.cts != null && !existing.isPaused)
+ {
+ try
+ {
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Updating existing active decoder for layer {layerKey}");
+ _decoders[layerKey] = (existing.decoder, existing.cts, layer, existing.lastFrame, existing.isPaused, existing.savedPosition);
 
-      var decoder = new FFmpegUnifiedDecoder(layer.SourcePath, w, h, ffmpegExecutable)
-         {
-       Loop = true,
-   AudioEnabled = playAudio || layer.PlayAudio,
-          Volume = (float)Math.Max(0.0, Math.Min(1.0, layer.Volume)),
-          Muted = layer.Muted
-     };
+ // Update audio settings on existing decoder
+ existing.decoder.AudioEnabled = playAudio || layer.PlayAudio;
+ existing.decoder.Volume =1.0f; // Fixed volume at100%
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Error updating existing decoder for {layerKey}: {ex}");
+ return false;
+ }
 
-   var cts = new CancellationTokenSource();
+ return true;
+ }
 
-   // Subscribe to timestamped frames to allow AV sync work
-    decoder.FrameDecodedWithTimestamp += (bmp, pts) =>
-            {
-         // Currently we don't implement sample scheduling here; this event allows us to record PTS for future sync.
-           // Could store _latestVideoPts[layerKey] = pts for scheduler.
-      };
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Creating new decoder for layer {layerKey}");
 
-            // Process frames on UI thread to avoid WPF cross-thread exceptions
-        decoder.FrameDecoded += bmp =>
-            {
-     if (bmp == null) return;
-         // Dispatch full WPF processing to UI thread
-              InvokeOnUi(() =>
-    {
-          try
-         {
-            ProcessDecodedFrameOnUi(layer, layerKey, decoder, cts, bmp, w, h);
-          }
-           catch { }
-                });
-            };
+ var decoder = new FFmpegUnifiedDecoder(layer.SourcePath, w, h, ffmpegExecutable)
+ {
+ Loop = true,
+ AudioEnabled = playAudio || layer.PlayAudio,
+ Volume =1.0f // Fixed volume at100%
+ };
 
-            // Preserve existing last frame
-       BitmapSource? existingLast = null;
-  if (_decoders.TryGetValue(layerKey, out var existingTuple)) existingLast = existingTuple.lastFrame;
-       _decoders.AddOrUpdate(layerKey, (decoder, cts, layer, existingLast), (k, old) => (decoder, cts, layer, old.lastFrame));
+ var cts = new CancellationTokenSource();
 
-      // Start decoder
-            _ = Task.Run(async () =>
-    {
-                try
-     {
-         await decoder.StartAsync(cts.Token).ConfigureAwait(false);
-                }
-            catch
-       {
-  await UnregisterLayerAsync(layerKey).ConfigureAwait(false);
-     }
-  }, cts.Token);
+ // Subscribe to timestamped frames to allow AV sync work
+ decoder.FrameDecodedWithTimestamp += (bmp, pts) => { };
 
-return true;
-        }
+ // Process frames on UI thread to avoid WPF cross-thread exceptions
+ decoder.FrameDecoded += bmp =>
+ {
+ if (bmp == null) return;
+ InvokeOnUi(() =>
+ {
+ try
+ {
+ ProcessDecodedFrameOnUi(layer, layerKey, decoder, cts, bmp, w, h);
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Error processing frame for {layerKey}: {ex}");
+ }
+ });
+ };
 
-        private void ProcessDecodedFrameOnUi(LayerModel layer, string layerKey, FFmpegUnifiedDecoder decoder, CancellationTokenSource cts, BitmapSource bmp, int defaultW, int defaultH)
-        {
-   if (bmp == null) return;
+ // Preserve existing last frame if any
+ BitmapSource? existingLast = null;
+ if (_decoders.TryGetValue(layerKey, out var existingTuple)) existingLast = existingTuple.lastFrame;
+ _decoders.AddOrUpdate(layerKey, (decoder, cts, layer, existingLast, false, TimeSpan.Zero), (k, old) => (decoder, cts, layer, old.lastFrame, false, old.savedPosition));
 
-     BitmapSource sourceFrozen = bmp;
-         try
-     {
-              if (!sourceFrozen.IsFrozen)
-             {
-    var clone = sourceFrozen.Clone();
-  clone.Freeze();
-        sourceFrozen = clone;
-    }
-            }
-       catch { }
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Starting decoder task for layer {layerKey}");
 
-        BitmapSource bmpToSubmit = sourceFrozen;
+ // Start decoder
+ _ = Task.Run(async () =>
+ {
+ try
+ {
+ await decoder.StartAsync(cts.Token).ConfigureAwait(false);
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Decoder started successfully for layer {layerKey}");
+ }
+ catch (OperationCanceledException)
+ {
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Decoder start cancelled for layer {layerKey} - This is normal during pause");
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.RegisterLayerAsync: Decoder start failed for layer {layerKey}: {ex}");
+ await UnregisterLayerAsync(layerKey).ConfigureAwait(false);
+ }
+ }, cts.Token);
 
-     try
-      {
-      if (Math.Abs(layer.RotationDegrees) > 1e-6 && sourceFrozen != null)
-          {
-      bmpToSubmit = RotateBitmap(sourceFrozen, layer.RotationDegrees);
-         }
-            }
-            catch
-            {
-      bmpToSubmit = sourceFrozen;
-          }
+ return true;
+ }
 
-            try { if (!bmpToSubmit.IsFrozen) try { bmpToSubmit.Freeze(); } catch { } } catch { }
+ private void ProcessDecodedFrameOnUi(LayerModel layer, string layerKey, FFmpegUnifiedDecoder decoder, CancellationTokenSource cts, BitmapSource bmp, int defaultW, int defaultH)
+ {
+ if (bmp == null) return;
 
-try
-    {
-        _decoders.AddOrUpdate(layerKey,
-       (decoder, cts, layer, bmpToSubmit),
-       (k, old) => (old.decoder ?? decoder, old.cts ?? cts, old.model, bmpToSubmit));
-    }
-            catch { }
+ BitmapSource sourceFrozen = bmp;
+ try
+ {
+ if (!sourceFrozen.IsFrozen)
+ {
+ var clone = sourceFrozen.Clone();
+ clone.Freeze();
+ sourceFrozen = clone;
+ }
+ }
+ catch { }
 
-            // Do not forward raw decoded frames directly to fullscreen hosts here. The renderer composes layers
-            // and RendererManager mirrors composed frames to any registered fullscreen windows. Forwarding raw
-            // frames from the decoder directly caused duplicate SetFrame calls and cross-thread access issues.
+ BitmapSource bmpToSubmit = sourceFrozen;
 
-        var destRect = new Rect(layer.X, layer.Y, layer.Width > 0 ? layer.Width : defaultW, layer.Height > 0 ? layer.Height : defaultH);
+ try
+ {
+ if (Math.Abs(layer.RotationDegrees) >1e-6 && sourceFrozen != null)
+ {
+ bmpToSubmit = RotateBitmap(sourceFrozen, layer.RotationDegrees);
+ }
+ }
+ catch
+ {
+ bmpToSubmit = sourceFrozen;
+ }
 
-        if (!layer.PreviewOnly && layer.Visible)
-      {
-     try
-    {
-  // No destQuad available here (this is a simple per-layer rect submission).
-       _rendererManager.SubmitLayerFrameForMonitor(layer.Id, bmpToSubmit, destRect, null, layer.Opacity, -1);
-              }
-  catch (Exception ex) { Debug.WriteLine($"VideoService: SubmitLayerFrame failed: {ex}"); }
-          }
+ try { if (!bmpToSubmit.IsFrozen) try { bmpToSubmit.Freeze(); } catch { } } catch { }
 
-      try
-{
-                foreach (var kv in _meshLayers.ToArray())
-       {
-        var mesh = kv.Value;
-      if (mesh == null) continue;
-      if (string.IsNullOrEmpty(mesh.SourceId)) continue;
-              if (mesh.SourceId != layer.Id) continue;
+ try
+ {
+ if (_decoders.TryGetValue(layerKey, out var current) &&
+ current.decoder == decoder &&
+ current.cts == cts)
+ {
+ _decoders.AddOrUpdate(layerKey,
+ (decoder, cts, layer, bmpToSubmit, false, TimeSpan.Zero),
+ (k, old) => (old.decoder ?? decoder, old.cts ?? cts, old.model, bmpToSubmit, old.isPaused, old.savedPosition));
+ }
+ else
+ {
+ Debug.WriteLine($"VideoService: Ignoring frame for {layerKey} from obsolete decoder");
+ return;
+ }
+ }
+ catch { }
+
+ var destRect = new Rect(layer.X, layer.Y, layer.Width >0 ? layer.Width : defaultW, layer.Height >0 ? layer.Height : defaultH);
+
+ if (!layer.PreviewOnly && layer.Visible)
+ {
+ try
+ {
+ _rendererManager.SubmitLayerFrameForMonitor(layer.Id, bmpToSubmit, destRect, null, layer.Opacity, layer.TargetMonitorIndex);
+ }
+ catch (Exception ex) { Debug.WriteLine($"VideoService: SubmitLayerFrame failed: {ex}"); }
+ }
+
+ try
+ {
+ foreach (var kv in _meshLayers.ToArray())
+ {
+ var mesh = kv.Value;
+ if (mesh == null) continue;
+ if (string.IsNullOrEmpty(mesh.SourceId)) continue;
+ if (mesh.SourceId != layer.Id) continue;
  if (!mesh.Visible) continue;
 
-       BitmapSource frameForMesh = bmpToSubmit;
-            try
+ BitmapSource frameForMesh = bmpToSubmit;
+ try
  {
-            // Crop to the mesh's MeshPoints (input selection) so only the selected portion is submitted to renderer
-           float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
-    foreach (var p in mesh.MeshPoints)
-            {
-          minX = Math.Min(minX, p.X);
-      minY = Math.Min(minY, p.Y);
-           maxX = Math.Max(maxX, p.X);
-              maxY = Math.Max(maxY, p.Y);
-      }
+ float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
+ foreach (var p in mesh.MeshPoints)
+ {
+ minX = Math.Min(minX, p.X);
+ minY = Math.Min(minY, p.Y);
+ maxX = Math.Max(maxX, p.X);
+ maxY = Math.Max(maxY, p.Y);
+ }
 
-          minX = Math.Max(0f, Math.Min(1f, minX));
+ minX = Math.Max(0f, Math.Min(1f, minX));
  minY = Math.Max(0f, Math.Min(1f, minY));
-             maxX = Math.Max(0f, Math.Min(1f, maxX));
-       maxY = Math.Max(0f, Math.Min(1f, maxY));
+ maxX = Math.Max(0f, Math.Min(1f, maxX));
+ maxY = Math.Max(0f, Math.Min(1f, maxY));
 
-          int srcW = frameForMesh.PixelWidth; int srcH = frameForMesh.PixelHeight;
-int srcX = (int)Math.Floor(minX * srcW);
-       int srcY = (int)Math.Floor(minY * srcH);
-   int cropW = Math.Max(1, (int)Math.Ceiling((maxX - minX) * srcW));
-   int cropH = Math.Max(1, (int)Math.Ceiling((maxY - minY) * srcH));
+ int srcW = frameForMesh.PixelWidth; int srcH = frameForMesh.PixelHeight;
+ int srcX = (int)Math.Floor(minX * srcW);
+ int srcY = (int)Math.Floor(minY * srcH);
+ int cropW = Math.Max(1, (int)Math.Ceiling((maxX - minX) * srcW));
+ int cropH = Math.Max(1, (int)Math.Ceiling((maxY - minY) * srcH));
 
-      if (srcX < 0) srcX = 0; if (srcY < 0) srcY = 0;
-           if (srcX + cropW > srcW) cropW = srcW - srcX;
-      if (srcY + cropH > srcH) cropH = srcH - srcY;
+ if (srcX <0) srcX =0; if (srcY <0) srcY =0;
+ if (srcX + cropW > srcW) cropW = srcW - srcX;
+ if (srcY + cropH > srcH) cropH = srcH - srcY;
 
-           if (cropW > 0 && cropH > 0)
-           {
-     var cb = new CroppedBitmap(frameForMesh, new Int32Rect(srcX, srcY, cropW, cropH));
-          try { cb.Freeze(); } catch { }
-       frameForMesh = cb;
-              }
-            }
-            catch { frameForMesh = bmpToSubmit; }
-
-          var meshDest = new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height));
-      try
-       {
-    // If the mesh provides OutputMeshPoints, build a destQuad in renderer coordinates
-    Point[]? destQuad = null;
-      try
-         {
-      // Prefer mapping normalized output mesh points to renderer pixels via RendererManager
-       try
-          {
-              destQuad = _rendererManager.MapNormalizedToRendererPoints(mesh.OutputMeshPoints, mesh.TargetMonitorIndex >= 0 ? mesh.TargetMonitorIndex : null);
-     }
-    catch (Exception exMap)
-        {
-     Debug.WriteLine($"VideoService: MapNormalizedToRendererPoints threw: {exMap}");
-       destQuad = null;
-                  }
-
-            // Fallback: construct from mesh.X/Y + normalized offsets if MapNormalizedToRendererPoints unavailable
-      if (destQuad == null)
-              {
-               var pts = mesh.OutputMeshPoints;
-   if (pts != null && pts.Length >= 4)
-       {
-            destQuad = new Point[4]
-                   {
-         new Point(mesh.X + pts[0].X * mesh.Width, mesh.Y + pts[0].Y * mesh.Height), // TL
-         new Point(mesh.X + pts[1].X * mesh.Width, mesh.Y + pts[1].Y * mesh.Height), // TR
-         new Point(mesh.X + pts[2].X * mesh.Width, mesh.Y + pts[2].Y * mesh.Height), // BL
-           new Point(mesh.X + pts[3].X * mesh.Width, mesh.Y + pts[3].Y * mesh.Height)  // BR
-            };
+ if (cropW >0 && cropH >0)
+ {
+ var cb = new CroppedBitmap(frameForMesh, new Int32Rect(srcX, srcY, cropW, cropH));
+ try { cb.Freeze(); } catch { }
+ frameForMesh = cb;
  }
-             else
-         {
-          Debug.WriteLine("VideoService: OutputMeshPoints not available for mesh, destQuad remains null");
-    }
-  }
-
-          if (destQuad == null)
-    {
-     Debug.WriteLine($"VideoService: destQuad is null for mesh {mesh.Id}, mesh.TargetMonitorIndex={mesh.TargetMonitorIndex}");
-           }
-       }
-      catch (Exception exQuad) { Debug.WriteLine($"VideoService: build destQuad failed: {exQuad}"); destQuad = null; }
-
-       _rendererManager.SubmitLayerFrameForMonitor(mesh.Id ?? Guid.NewGuid().ToString("N"), frameForMesh, meshDest, destQuad, mesh.Opacity, mesh.TargetMonitorIndex);
-      }
-        catch (Exception ex) { Debug.WriteLine($"VideoService: SubmitLayerFrame for mesh failed: {ex}"); }
-
-     // Do not directly forward mesh frames to fullscreen hosts; renderer will mirror composed output.
-        }
-     }
-            catch (Exception ex) { Debug.WriteLine($"VideoService: Post-frame handling failed: {ex}"); }
-
-     try
-            {
-             var now = DateTime.UtcNow;
-             var last = _lastFrameSent.GetOrAdd(layerKey, DateTime.MinValue);
-     if (now - last >= _minFrameInterval)
-    {
-       _lastFrameSent[layerKey] = now;
-         try { FrameDecoded?.Invoke(layer.Id ?? string.Empty, bmpToSubmit); } catch { }
-           }
-      }
-   catch { }
-        }
-
-        public Task RegisterMeshLayerAsync(LayerModel mesh)
-        {
-        if (mesh == null) throw new ArgumentNullException(nameof(mesh));
-          if (string.IsNullOrEmpty(mesh.Id)) mesh.Id = Guid.NewGuid().ToString("N");
-   _meshLayers[mesh.Id] = mesh;
-
-            // Set mesh dimensions to renderer output size for proper full-screen mapping
-            mesh.Width = _rendererManager.OutputWidth;
-            mesh.Height = _rendererManager.OutputHeight;
-
-         try
-   {
-                if (!string.IsNullOrEmpty(mesh.SourceId) && _decoders.TryGetValue(mesh.SourceId, out var tup) && tup.model != null)
-       {
-         try { tup.model.PreviewOnly = true; } catch { }
-      }
-            }
-  catch { }
-
-            try
-            {
-                if (!string.IsNullOrEmpty(mesh.SourceId) && _decoders.TryGetValue(mesh.SourceId, out var tuple) && tuple.lastFrame != null)
-                {
-             var sourceFrame = tuple.lastFrame;
-         BitmapSource frameForMesh = sourceFrame;
-try
-     {
-     // Removed cropping to stretch the full source frame to fill the output mesh
-           }
- catch { frameForMesh = sourceFrame; }
-
-            var meshDest = new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height));
-   try
-    {
-              // Try to build destQuad from normalized OutputMeshPoints if available
-   Point[]? destQuad = null;
-      try { destQuad = _rendererManager.MapNormalizedToRendererPoints(mesh.OutputMeshPoints); } catch { destQuad = null; }
-        if (destQuad == null) destQuad = null; // keep as null to draw rect if mapping unavailable
-
-             _rendererManager.SubmitLayerFrame(mesh.Id ?? Guid.NewGuid().ToString("N"), frameForMesh, meshDest, destQuad, mesh.Opacity);
-         }
-            catch (Exception ex)
-        {
-           Debug.WriteLine($"VideoService.RegisterMeshLayerAsync: SubmitLayerFrame failed: {ex}");
-                 }
-   }
  }
-            catch { }
+ catch { frameForMesh = bmpToSubmit; }
 
+ var meshDest = new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height));
+ try
+ {
+ Point[]? destQuad = null;
+ try
+ {
+ destQuad = _rendererManager.MapNormalizedToRendererPoints(mesh.OutputMeshPoints, mesh.TargetMonitorIndex >=0 ? mesh.TargetMonitorIndex : null);
+ }
+ catch (Exception exMap)
+ {
+ Debug.WriteLine($"VideoService: MapNormalizedToRendererPoints threw: {exMap}");
+ destQuad = null;
+ }
 
-     return Task.CompletedTask;
-   }
+ if (destQuad == null)
+ {
+ var pts = mesh.OutputMeshPoints;
+ if (pts != null && pts.Length >=4)
+ {
+ destQuad = new Point[4]
+ {
+ new Point(mesh.X + pts[0].X * mesh.Width, mesh.Y + pts[0].Y * mesh.Height),
+ new Point(mesh.X + pts[1].X * mesh.Width, mesh.Y + pts[1].Y * mesh.Height),
+ new Point(mesh.X + pts[2].X * mesh.Width, mesh.Y + pts[2].Y * mesh.Height),
+ new Point(mesh.X + pts[3].X * mesh.Width, mesh.Y + pts[3].Y * mesh.Height)
+ };
+ }
+ else
+ {
+ Debug.WriteLine("VideoService: OutputMeshPoints not available for mesh, destQuad remains null");
+ }
+ }
 
-        public Task UnregisterMeshLayerAsync(string meshId)
-  {
-            if (string.IsNullOrEmpty(meshId)) return Task.CompletedTask;
-    if (_meshLayers.TryRemove(meshId, out var removed))
-          {
-  try
-  {
-          if (removed != null && !string.IsNullOrEmpty(removed.SourceId))
-             {
-         bool any = _meshLayers.Values.Any(m => m != null && m.SourceId == removed.SourceId);
-              if (!any)
-        {
-     // No more meshes for this source, clear the output for this source
-  InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(removed.SourceId, null, new Rect(), null, 0.0); } catch { } });
-            }
-    }
-  }
-                catch { }
-         }
-        return Task.CompletedTask;
-        }
+ InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(mesh.Id ?? Guid.NewGuid().ToString("N"), frameForMesh, meshDest, destQuad, mesh.Opacity); } catch { } });
+ }
+ catch (Exception ex) { Debug.WriteLine($"VideoService: SubmitLayerFrame for mesh failed: {ex}"); }
+ }
+ }
+ catch (Exception ex) { Debug.WriteLine($"VideoService: Post-frame handling failed: {ex}"); }
 
-        private static BitmapSource RotateBitmap(BitmapSource src, double degrees)
-        {
-  if (src == null) return src;
-     var deg = degrees % 360.0;
-            if (deg < 0) deg += 360.0;
-            if (Math.Abs(deg) < 1e-6) return src;
+ try
+ {
+ var now = DateTime.UtcNow;
+ var last = _lastFrameSent.GetOrAdd(layerKey, DateTime.MinValue);
+ if (now - last >= _minFrameInterval)
+ {
+ _lastFrameSent[layerKey] = now;
+ try { FrameDecoded?.Invoke(layer.Id ?? string.Empty, bmpToSubmit); } catch { }
+ }
+ }
+ catch { }
+ }
 
-            try
-       {
-         var rt = new RotateTransform(deg);
-  var tb = new TransformedBitmap(src, rt);
-                try { tb.Freeze(); } catch { }
-       return tb;
-          }
-            catch
-     {
-         return src;
-     }
-        }
+ public Task RegisterMeshLayerAsync(LayerModel mesh)
+ {
+ if (mesh == null) throw new ArgumentNullException(nameof(mesh));
+ if (string.IsNullOrEmpty(mesh.Id)) mesh.Id = Guid.NewGuid().ToString("N");
+ _meshLayers[mesh.Id] = mesh;
 
-     public Task UnregisterLayerAsync(string layerId)
-  {
-         if (string.IsNullOrEmpty(layerId)) return Task.CompletedTask;
+ // Set mesh dimensions to renderer output size for proper full-screen mapping
+ mesh.Width = _rendererManager.OutputWidth;
+ mesh.Height = _rendererManager.OutputHeight;
+
+ try
+ {
+ if (!string.IsNullOrEmpty(mesh.SourceId) && _decoders.TryGetValue(mesh.SourceId, out var tup) && tup.model != null)
+ {
+ try { tup.model.PreviewOnly = true; } catch { }
+ }
+ }
+ catch { }
+
+ try
+ {
+ if (!string.IsNullOrEmpty(mesh.SourceId) && _decoders.TryGetValue(mesh.SourceId, out var tuple) && tuple.lastFrame != null)
+ {
+ var sourceFrame = tuple.lastFrame;
+ BitmapSource frameForMesh = sourceFrame;
+ try { /* intentionally left blank: no cropping */ } catch { frameForMesh = sourceFrame; }
+
+ var meshDest = new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height));
+ try
+ {
+ Point[]? destQuad = null;
+ try { destQuad = _renderer_manager_safe_map(mesh.OutputMeshPoints); } catch { destQuad = null; }
+ InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(mesh.Id ?? Guid.NewGuid().ToString("N"), frameForMesh, meshDest, destQuad, mesh.Opacity); } catch { } });
+ }
+ catch (Exception ex) { Debug.WriteLine($"VideoService.RegisterMeshLayerAsync: SubmitLayerFrame failed: {ex}"); }
+ }
+ }
+ catch { }
+
+ return Task.CompletedTask;
+ }
+
+ // small helper to call MapNormalizedToRendererPoints and swallow exceptions
+ private Point[]? _renderer_manager_safe_map(Vector2[]? pts)
+ {
+ try { return _rendererManager.MapNormalizedToRendererPoints(pts); } catch { return null; }
+ }
+
+ public Task UnregisterMeshLayerAsync(string meshId)
+ {
+ if (string.IsNullOrEmpty(meshId)) return Task.CompletedTask;
+ if (_meshLayers.TryRemove(meshId, out var removed))
+ {
+ try
+ {
+ if (removed != null && !string.IsNullOrEmpty(removed.SourceId))
+ {
+ bool any = _meshLayers.Values.Any(m => m != null && m.SourceId == removed.SourceId);
+ if (!any)
+ {
+ // No more meshes for this source, clear the output for this source
+ InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(removed.SourceId, null, new Rect(), null,0.0); } catch { } });
+ }
+ }
+ }
+ catch { }
+ }
+ return Task.CompletedTask;
+ }
+
+ // helper to snapshot mesh layers to avoid enumerating concurrent dictionary directly in some places
+ private LayerModel[] _meshLayersSnapshot()
+ {
+ try { return _meshLayers.Values.ToArray(); } catch { return Array.Empty<LayerModel>(); }
+ }
+
+ private static BitmapSource RotateBitmap(BitmapSource src, double degrees)
+ {
+ if (src == null) return src;
+ var deg = degrees %360.0;
+ if (deg <0) deg +=360.0;
+ if (Math.Abs(deg) <1e-6) return src;
+
+ try
+ {
+ var rt = new RotateTransform(deg);
+ var tb = new TransformedBitmap(src, rt);
+ try { tb.Freeze(); } catch { }
+ return tb;
+ }
+ catch
+ {
+ return src;
+ }
+ }
+
+ public Task UnregisterLayerAsync(string layerId)
+ {
+ if (string.IsNullOrEmpty(layerId)) return Task.CompletedTask;
  if (_decoders.TryRemove(layerId, out var tuple))
-{
-          try
-  {
-    tuple.cts?.Cancel();
-     tuple.decoder?.Dispose();
-        tuple.cts?.Dispose();
-                }
-        catch { }
-         }
-
-   _lastFrameSent.TryRemove(layerId, out _);
-
-        return Task.CompletedTask;
-      }
-
-        public Task PauseLayerAsync(string layerId)
-        {
-            if (string.IsNullOrEmpty(layerId)) return Task.CompletedTask;
-     if (_decoders.TryGetValue(layerId, out var t))
-         {
-     try
-    {
-           t.cts?.Cancel();
-         t.decoder?.Dispose();
-            _decoders[layerId] = (null, null, t.model, t.lastFrame);
-         }
-     catch { }
-            }
-
-            return Task.CompletedTask;
-        }
-
-     public async Task ResumeLayerAsync(string layerId)
-        {
-      if (string.IsNullOrEmpty(layerId)) return;
-     if (_decoders.TryGetValue(layerId, out var t) && t.model != null && (t.decoder == null))
-            {
-        var layer = t.model;
-            var playAudio = layer.PlayAudio;
-          await RegisterLayerAsync(layer, playAudio).ConfigureAwait(false);
-            }
-        }
-
-        public Task PauseAllAsync() { foreach (var id in _decoders.Keys) _ = PauseLayerAsync(id); return Task.CompletedTask; }
-        public Task ResumeAllAsync() { foreach (var kv in _decoders) if (kv.Value.model != null && kv.Value.decoder == null) _ = ResumeLayerAsync(kv.Key); return Task.CompletedTask; }
- public Task RestartAllAsync() { foreach (var id in _decoders.Keys) _ = RestartLayerAsync(id); return Task.CompletedTask; }
-
-        public async Task RestartLayerAsync(string layerId)
-        {
-      if (string.IsNullOrEmpty(layerId)) return;
-            if (_decoders.TryGetValue(layerId, out var t) && t.model != null)
-            {
-    await UnregisterLayerAsync(layerId).ConfigureAwait(false);
-    await RegisterLayerAsync(t.model, t.model.PlayAudio). ConfigureAwait(false);
-    }
-  }
-
-        private string ResolveFfmpegExecutable()
-        {
-       var exe = string.IsNullOrWhiteSpace(_ffmpegPath) ? "ffmpeg" : _ffmpegPath;
-         try
-            {
-var psi = new ProcessStartInfo
-         {
-        FileName = exe,
-            Arguments = "-version",
-      UseShellExecute = false,
-  RedirectStandardOutput = true,
-     RedirectStandardError = true,
-        CreateNoWindow = true
-           };
-     using var proc = Process.Start(psi);
-        if (proc == null) throw new InvalidOperationException("Failed to start ffmpeg process.");
-   if (!proc.WaitForExit(1500)) { try { proc.Kill(true); } catch { } throw new InvalidOperationException("ffmpeg did not respond in time."); }
-      return exe;
-       }
-     catch (Exception ex)
-   {
-      throw new InvalidOperationException($"ffmpeg executable not found or failed to run. Ensure ffmpeg is installed and on PATH, or provide a valid ffmpeg path. Underlying error: {ex.Message}", ex);
-            }
-  }
-
-    // Public wrapper: start audio for an existing registered layer using its SourcePath
-        public void StartAudioForLayer(string layerId)
-        {
-    if (string.IsNullOrEmpty(layerId)) return;
-            try
-      {
-                if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null)
-            {
-            tup.decoder.AudioEnabled = true;
-          }
-            }
+ {
+ try
+ {
+ try { tuple.cts?.Cancel(); } catch (Exception ex) { Debug.WriteLine($"VideoService.UnregisterLayerAsync: Error canceling token for {layerId}: {ex}"); }
+ try { Task.Delay(300).Wait(); } catch { }
+ try { tuple.decoder?.Dispose(); } catch (Exception ex) { Debug.WriteLine($"VideoService.UnregisterLayerAsync: Error disposing decoder for {layerId}: {ex}"); }
+ try { tuple.cts?.Dispose(); } catch (Exception ex) { Debug.WriteLine($"VideoService.UnregisterLayerAsync: Error disposing cts for {layerId}: {ex}"); }
+ }
  catch (Exception ex)
-    {
-         Debug.WriteLine($"VideoService: StartAudioForLayer failed: {ex}");
-            }
-  }
+ {
+ Debug.WriteLine($"VideoService.UnregisterLayerAsync: Error for {layerId}: {ex}");
+ }
+ }
 
-        // Stop audio playback for a given layer id
-        public void StopAudioForLayer(string layerId)
-        {
-         if (string.IsNullOrEmpty(layerId)) return;
-      try
-    {
-  if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null)
-      {
-        tup.decoder.AudioEnabled = false;
-         }
-        }
-       catch (Exception ex)
-            {
-         Debug.WriteLine($"VideoService: StopAudioForLayer failed: {ex}");
-          }
-        }
+ _lastFrameSent.TryRemove(layerId, out _);
 
-        // Set per-layer volume (0.0 - 1.0). We apply this by adjusting the unified decoder's volume
-        public void SetLayerVolume(string layerId, float volume)
-      {
-      if (string.IsNullOrEmpty(layerId)) return;
-  try
-            {
-    if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null)
-       {
-    tup.decoder.Volume = Math.Max(0f, Math.Min(1f, volume));
-        }
-            }
-   catch (Exception ex)
-   {
-     Debug.WriteLine($"VideoService: SetLayerVolume failed: {ex}");
-}
-        }
+ return Task.CompletedTask;
+ }
 
-        public void SetLayerMute(string layerId, bool muted)
-        {
-     if (string.IsNullOrEmpty(layerId)) return;
-    try
-      {
-                if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null)
-     {
-      tup.decoder.Muted = muted;
-            }
-            }
+ public Task PauseLayerAsync(string layerId)
+ {
+ if (string.IsNullOrEmpty(layerId)) return Task.CompletedTask;
+
+ Debug.WriteLine($"VideoService.PauseLayerAsync: Attempting to pause layer {layerId}");
+
+ if (!_decoders.TryGetValue(layerId, out var t))
+ {
+ Debug.WriteLine($"VideoService.PauseLayerAsync: Layer {layerId} not found in decoders");
+ return Task.CompletedTask;
+ }
+
+ try
+ {
+ Debug.WriteLine($"VideoService.PauseLayerAsync: Pausing layer {layerId}");
+
+ TimeSpan currentPosition = TimeSpan.Zero;
+ try
+ {
+ if (t.decoder != null)
+ {
+ currentPosition = t.decoder.CurrentPosition;
+ t.decoder.SaveCurrentPosition(); // This stops the timer and saves position
+ Debug.WriteLine($"VideoService.PauseLayerAsync: Saved position {currentPosition.TotalSeconds:F2}s for layer {layerId}");
+ }
+ }
  catch (Exception ex)
-       {
-             Debug.WriteLine($"VideoService: SetLayerMute failed: {ex}");
-   }
-  }
+ {
+ Debug.WriteLine($"VideoService.PauseLayerAsync: Error saving position for {layerId}: {ex}");
+ }
 
-        public void Dispose()
-        {
-   foreach (var kv in _decoders)
-     {
-          try { kv.Value.cts?.Cancel(); kv.Value.decoder?.Dispose(); kv.Value.cts?.Dispose(); } catch { }
-            }
-  _decoders.Clear(); _meshLayers.Clear();
-        _lastFrameSent.Clear();
-        }
+ try { t.cts?.Cancel(); } catch (Exception ex) { Debug.WriteLine($"VideoService.PauseLayerAsync: Error canceling token for {layerId}: {ex}"); }
 
-        public async Task HideSourceOutputAndMeshesAsync(string sourceId)
-        {
-            if (string.IsNullOrEmpty(sourceId)) return;
-         foreach (var kv in _decoders)
-            {
-        var (decoder, cts, model, lastFrame) = kv.Value;
-                if (model != null && model.Id == sourceId)
-            {
-       try { model.Visible = false; await PauseLayerAsync(model.Id ?? string.Empty).ConfigureAwait(false); InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(model.Id ?? string.Empty, null, new Rect(model.X, model.Y, Math.Max(1, model.Width), Math.Max(1, model.Height)), null, model.Opacity); } catch { } }); } catch { }
-            }
-        }
+ try { Task.Delay(700).Wait(); } catch { }
 
-          foreach (var kv in _meshLayers)
-    {
-    var mesh = kv.Value; if (mesh == null) continue;
-    if (mesh.SourceId == sourceId)
-        {
-  try { mesh.Visible = false; InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(mesh.Id ?? string.Empty, null, new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height)), null, mesh.Opacity); } catch { } }); } catch { }
-           }
-      }
-        }
+ try { t.decoder?.Dispose(); } catch (Exception ex) { Debug.WriteLine($"VideoService.PauseLayerAsync: Error disposing decoder for {layerId}: {ex}"); }
 
-        public async Task ShowSourceOutputAndMeshesAsync(string sourceId)
-        {
-         if (string.IsNullOrEmpty(sourceId)) return;
-  foreach (var kv in _decoders)
-            {
-    var (decoder, cts, model, lastFrame) = kv.Value;
-     if (model != null && model.Id == sourceId)
-                {
-      try { model.Visible = true; await ResumeLayerAsync(model.Id ?? string.Empty).ConfigureAwait(false); } catch { }
-  }
-   }
+ _decoders[layerId] = (null, t.cts, t.model, t.lastFrame, true, currentPosition);
 
-         foreach (var kv in _mesh_layers_snapshot())
-            {
-    var mesh = kv; if (mesh == null) continue;
-   if (mesh.SourceId == sourceId)
-     {
-          try
-      {
-      mesh.Visible = true;
-    if (!string.IsNullOrEmpty(mesh.SourceId) && _decoders.TryGetValue(mesh.SourceId, out var tup) && tup.lastFrame != null)
-          {
-      var frameForMesh = tup.lastFrame;
-      try
-            {
-          // Removed cropping to stretch the full source frame to fill the output mesh
-              }
-      catch { }
+ Debug.WriteLine($"VideoService.PauseLayerAsync: Layer {layerId} paused successfully with position {currentPosition.TotalSeconds:F2}s");
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.PauseLayerAsync failed for {layerId}: {ex}");
+ }
 
-            var meshDest = new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height));
-             InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(mesh.Id ?? Guid.NewGuid().ToString("N"), frameForMesh, meshDest, null, mesh.Opacity); } catch { } });
-      }
-   }
-    catch { }
-             }
-    }
-        }
+ return Task.CompletedTask;
+ }
 
-        // helper to snapshot mesh layers to avoid enumerating concurrent dictionary directly in some places
-        private LayerModel[] _mesh_layers_snapshot()
-    {
-    try { return _meshLayers.Values.ToArray(); } catch { return Array.Empty<LayerModel>(); }
-        }
+ public async Task ResumeLayerAsync(string layerId)
+ {
+ if (string.IsNullOrEmpty(layerId)) return;
 
-     public bool TryGetLastFrame(string layerId, out BitmapSource? frame)
-        {
-            frame = null;
-            if (string.IsNullOrEmpty(layerId)) return false;
-    if (_decoders.TryGetValue(layerId, out var tuple) && tuple.lastFrame != null)
-            {
-           frame = tuple.lastFrame;
-       return true;
-       }
-     return false;
-    }
-    }
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Attempting to resume layer {layerId}");
+
+ if (!_decoders.TryGetValue(layerId, out var t))
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Layer {layerId} not found in decoders");
+ return;
+ }
+
+ if (t.model == null)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Layer {layerId} has no model");
+ return;
+ }
+
+ if (!t.isPaused)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Layer {layerId} is not paused, skipping resume");
+ return;
+ }
+
+ try
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Resuming layer {layerId} from position {t.savedPosition.TotalSeconds:F2}s");
+
+ var layer = t.model;
+ var playAudio = layer.PlayAudio;
+ var savedPosition = t.savedPosition;
+
+ _decoders.TryRemove(layerId, out _);
+
+ var decoder = new FFmpegUnifiedDecoder(layer.SourcePath,
+ Math.Max(1, layer.Width >0 ? layer.Width :640),
+ Math.Max(1, layer.Height >0 ? layer.Height :480),
+ ResolveFfmpegExecutable())
+ {
+ Loop = true,
+ AudioEnabled = false, // enable audio after a short delay to avoid overlap
+ Volume =1.0f
+ };
+
+ decoder.SetResumePosition(savedPosition);
+
+ var cts = new CancellationTokenSource();
+
+ decoder.FrameDecodedWithTimestamp += (bmp, pts) => { };
+ decoder.FrameDecoded += bmp =>
+ {
+ if (bmp == null) return;
+ InvokeOnUi(() =>
+ {
+ try
+ {
+ ProcessDecodedFrameOnUi(layer, layerId, decoder, cts, bmp,
+ Math.Max(1, layer.Width >0 ? layer.Width :640),
+ Math.Max(1, layer.Height >0 ? layer.Height :480));
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Error processing frame for {layerId}: {ex}");
+ }
+ });
+ };
+
+ _decoders.AddOrUpdate(layerId, (decoder, cts, layer, t.lastFrame, false, savedPosition), (k, old) => (decoder, cts, layer, old.lastFrame, false, savedPosition));
+
+ _ = Task.Run(async () =>
+ {
+ try
+ {
+ await decoder.StartAsync(cts.Token).ConfigureAwait(false);
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Decoder started successfully for layer {layerId}");
+ }
+ catch (OperationCanceledException)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Decoder start cancelled for layer {layerId}");
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Decoder start failed for layer {layerId}: {ex}");
+ await UnregisterLayerAsync(layerId).ConfigureAwait(false);
+ }
+ }, cts.Token);
+
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Layer {layerId} resumed successfully");
+
+ // Delay enabling audio briefly to allow previous decoder/audio process to fully stop and avoid overlapping audio
+ _ = Task.Run(async () =>
+ {
+ try
+ {
+ await Task.Delay(300).ConfigureAwait(false);
+ try
+ {
+ if (_decoders.TryGetValue(layerId, out var cur) && cur.decoder == decoder)
+ {
+ // Wait a bit longer to ensure the buffer has some data before enabling
+ await Task.Delay(200).ConfigureAwait(false);
+ 
+ decoder.AudioEnabled = playAudio || layer.PlayAudio;
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Audio enabled for {layerId} (playAudio={playAudio}, layer.PlayAudio={layer.PlayAudio})");
+ }
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Enabling audio failed for {layerId}: {ex}");
+ }
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync: Audio enable task failed for {layerId}: {ex}");
+ }
+ });
+ }
+ catch (Exception ex)
+ {
+ Debug.WriteLine($"VideoService.ResumeLayerAsync failed for {layerId}: {ex}");
+ }
+ }
+
+ public void Dispose()
+ {
+ // Cancel and dispose all decoders cleanly
+ foreach (var kv in _decoders.ToArray())
+ {
+ try
+ {
+ var tup = kv.Value;
+ try { tup.cts?.Cancel(); } catch { }
+ try { tup.decoder?.Dispose(); } catch { }
+ try { tup.cts?.Dispose(); } catch { }
+ }
+ catch { }
+ }
+ _decoders.Clear();
+ try { _meshLayers.Clear(); } catch { }
+ _lastFrameSent.Clear();
+ }
+
+ private string ResolveFfmpegExecutable()
+ {
+ var exe = string.IsNullOrWhiteSpace(_ffmpegPath) ? "ffmpeg" : _ffmpegPath;
+ try
+ {
+ var psi = new ProcessStartInfo
+ {
+ FileName = exe,
+ Arguments = "-version",
+ UseShellExecute = false,
+ RedirectStandardOutput = true,
+ RedirectStandardError = true,
+ CreateNoWindow = true
+ };
+ using var proc = Process.Start(psi);
+ if (proc == null) throw new InvalidOperationException("Failed to start ffmpeg process.");
+ if (!proc.WaitForExit(1500)) { try { proc.Kill(true); } catch { } throw new InvalidOperationException("ffmpeg did not respond in time."); }
+ return exe;
+ }
+ catch (Exception ex)
+ {
+ throw new InvalidOperationException($"ffmpeg executable not found or failed to run. Ensure ffmpeg is installed and on PATH, or provide a valid ffmpeg path. Underlying error: {ex.Message}", ex);
+ }
+ }
+
+ public Task PauseAllAsync() => Task.WhenAll(_decoders.Keys.Select(id => PauseLayerAsync(id)).ToArray());
+ public Task ResumeAllAsync() => Task.WhenAll(_decoders.Where(kv => kv.Value.isPaused).Select(kv => ResumeLayerAsync(kv.Key)).ToArray());
+ public Task RestartAllAsync() => Task.WhenAll(_decoders.Keys.Select(id => RestartLayerAsync(id)).ToArray());
+
+ public async Task RestartLayerAsync(string layerId)
+ {
+ if (string.IsNullOrEmpty(layerId)) return;
+ if (!_decoders.TryGetValue(layerId, out var t) || t.model == null) return;
+ var model = t.model;
+ 
+ // CRITICAL: Get the playAudio state from the model which reflects the checkbox state
+ var playAudio = model.PlayAudio;
+ Debug.WriteLine($"VideoService.RestartLayerAsync: Restarting layer {layerId} with playAudio={playAudio}");
+ 
+ try { await UnregisterLayerAsync(layerId).ConfigureAwait(false); } catch { }
+ try { await RegisterLayerAsync(model, playAudio).ConfigureAwait(false); } catch (Exception ex) { Debug.WriteLine($"VideoService.RestartLayerAsync: Register failed for {layerId}: {ex}"); }
+ }
+
+ public void StartAudioForLayer(string layerId)
+ {
+ if (string.IsNullOrEmpty(layerId)) return;
+ if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null)
+ {
+ try { tup.decoder.AudioEnabled = true; } catch (Exception ex) { Debug.WriteLine($"StartAudioForLayer failed: {ex}"); }
+ }
+ }
+
+ public void StopAudioForLayer(string layerId)
+ {
+ if (string.IsNullOrEmpty(layerId)) return;
+ if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null)
+ {
+ try { tup.decoder.AudioEnabled = false; } catch (Exception ex) { Debug.WriteLine($"StopAudioForLayer failed: {ex}"); }
+ }
+ }
+
+ public bool TryGetLastFrame(string layerId, out BitmapSource? frame)
+ {
+ frame = null;
+ if (string.IsNullOrEmpty(layerId)) return false;
+ if (_decoders.TryGetValue(layerId, out var tup) && tup.lastFrame != null)
+ {
+ frame = tup.lastFrame;
+ return true;
+ }
+ return false;
+ }
+
+ public async Task HideSourceOutputAndMeshesAsync(string sourceId)
+ {
+ if (string.IsNullOrEmpty(sourceId)) return;
+ try
+ {
+ foreach (var kv in _decoders.ToArray())
+ {
+ var (decoder, cts, model, lastFrame, isPaused, savedPosition) = kv.Value;
+ if (model != null && model.Id == sourceId)
+ {
+ try
+ {
+ model.Visible = false;
+ await PauseLayerAsync(model.Id ?? string.Empty).ConfigureAwait(false);
+ InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(model.Id ?? string.Empty, null, new Rect(model.X, model.Y, Math.Max(1, model.Width), Math.Max(1, model.Height)), null, model.Opacity); } catch { } });
+ }
+ catch { }
+ }
+ }
+
+ foreach (var kv in _meshLayers.ToArray())
+ {
+ var mesh = kv.Value; if (mesh == null) continue;
+ if (mesh.SourceId == sourceId)
+ {
+ try { mesh.Visible = false; InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(mesh.Id ?? string.Empty, null, new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height)), null, mesh.Opacity); } catch { } }); } catch { }
+ }
+ }
+ }
+ catch { }
+ }
+
+ public async Task ShowSourceOutputAndMeshesAsync(string sourceId)
+ {
+ if (string.IsNullOrEmpty(sourceId)) return;
+ try
+ {
+ foreach (var kv in _decoders.ToArray())
+ {
+ var (decoder, cts, model, lastFrame, isPaused, savedPosition) = kv.Value;
+ if (model != null && model.Id == sourceId)
+ {
+ try { model.Visible = true; await ResumeLayerAsync(model.Id ?? string.Empty).ConfigureAwait(false); } catch { }
+ }
+ }
+
+ foreach (var mesh in _meshLayersSnapshot())
+ {
+ if (mesh == null) continue;
+ if (mesh.SourceId == sourceId)
+ {
+ try
+ {
+ mesh.Visible = true;
+ if (!string.IsNullOrEmpty(mesh.SourceId) && _decoders.TryGetValue(mesh.SourceId, out var tup) && tup.lastFrame != null)
+ {
+ var frameForMesh = tup.lastFrame;
+ var meshDest = new Rect(mesh.X, mesh.Y, Math.Max(1, mesh.Width), Math.Max(1, mesh.Height));
+ InvokeOnUi(() => { try { _rendererManager.SubmitLayerFrame(mesh.Id ?? Guid.NewGuid().ToString("N"), frameForMesh, meshDest, null, mesh.Opacity); } catch { } });
+ }
+ }
+ catch { }
+ }
+ }
+ }
+ catch { }
+ }
+ }
 }

--- a/ViewModels/ImportedVideoViewModel.cs
+++ b/ViewModels/ImportedVideoViewModel.cs
@@ -37,25 +37,11 @@ namespace ProjectionMapper.ViewModels
 
         public double Volume
         {
-            get => HostLayer?.Volume ?? 1.0;
+            get => 1.0; // Volume is now fixed at 100%
             set
             {
-                if (HostLayer == null) return;
-                if (Math.Abs(HostLayer.Volume - value) < 1e-6) return;
-                HostLayer.Volume = value;
-                RaisePropertyChanged();
-            }
-        }
-
-        public bool Muted
-        {
-            get => HostLayer?.Muted ?? false;
-            set
-            {
-                if (HostLayer == null) return;
-                if (HostLayer.Muted == value) return;
-                HostLayer.Muted = value;
-                RaisePropertyChanged();
+                // Volume setting is ignored - volume is fixed at 100%
+                // The setter is kept for compatibility with existing bindings
             }
         }
 
@@ -64,7 +50,6 @@ namespace ProjectionMapper.ViewModels
         {
             RaisePropertyChanged(nameof(PlayAudio));
             RaisePropertyChanged(nameof(Volume));
-            RaisePropertyChanged(nameof(Muted));
         }
     }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -30,8 +30,9 @@ namespace ProjectionMapper.ViewModels
             ImportCommand = new RelayCommand(ExecuteImportCommand);
             PreviewCommand = new RelayCommand(ExecutePreviewCommand);
 
-            PlayPauseCommand = new RelayCommand(ExecutePlayPauseCommand);
-            RestartCommand = new RelayCommand(ExecuteRestartCommand);
+            // Use AsyncRelayCommand for playback operations since they're async
+            PlayPauseCommand = new AsyncRelayCommand(ExecutePlayPauseCommandAsync);
+            RestartCommand = new AsyncRelayCommand(ExecuteRestartCommandAsync);
 
             CreateMeshCommand = new RelayCommand(ExecuteCreateMeshCommand, _ => SelectedImportedVideo != null);
             DeleteMeshCommand = new RelayCommand(ExecuteDeleteMeshCommand, _ => SelectedMeshLayer != null);
@@ -98,7 +99,7 @@ namespace ProjectionMapper.ViewModels
         public ICommand ImportCommand { get; }
         public ICommand PreviewCommand { get; }
 
-        // Playback
+        // Playback - now using AsyncRelayCommand
         public ICommand PlayPauseCommand { get; }
         public ICommand RestartCommand { get; }
 
@@ -114,8 +115,8 @@ namespace ProjectionMapper.ViewModels
         // Events surfaced to the host window so it can perform file dialogs / services
         public event Action? ImportRequested;
         public event Action? PreviewRequested;
-        public event Action? PlayPauseRequested;
-        public event Action? RestartRequested;
+        public event Func<System.Threading.Tasks.Task>? PlayPauseRequestedAsync;
+        public event Func<System.Threading.Tasks.Task>? RestartRequestedAsync;
 
         // Event requested when an imported video should be deleted (UI may show confirmation)
         public event Action<ImportedVideoViewModel?>? DeleteImportedRequested;
@@ -171,19 +172,29 @@ namespace ProjectionMapper.ViewModels
         }
 
         private bool _isPlaying = true;
-        private void ExecutePlayPauseCommand(object? _)
+        private async System.Threading.Tasks.Task ExecutePlayPauseCommandAsync()
         {
             _isPlaying = !_isPlaying;
-            PlayPauseRequested?.Invoke();
+
+            // Notify host to handle the async operation
+            if (PlayPauseRequestedAsync != null)
+            {
+                await PlayPauseRequestedAsync.Invoke();
+            }
+
             // Raise UI updates if you bind icon state
             RaisePropertyChanged(nameof(IsPlaying));
         }
 
         public bool IsPlaying => _isPlaying;
 
-        private void ExecuteRestartCommand(object? _)
+        private async System.Threading.Tasks.Task ExecuteRestartCommandAsync()
         {
-            RestartRequested?.Invoke();
+            // Notify host to handle the async operation
+            if (RestartRequestedAsync != null)
+            {
+                await RestartRequestedAsync.Invoke();
+            }
         }
 
         private LayerModel? _copiedMesh;

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -174,14 +174,6 @@
                             <TextBlock Text="Play Audio:" VerticalAlignment="Center" Margin="0,0,6,0" />
                             <CheckBox x:Name="PART_PlayAudioCheckbox" IsChecked="{Binding PlayAudio, Mode=TwoWay}" VerticalAlignment="Center" />
                         </StackPanel>
-                        <StackPanel Margin="0,6,0,0">
-                            <TextBlock Text="Volume:" FontWeight="Bold" />
-                            <Slider x:Name="PART_VolumeSlider" Minimum="0.0" Maximum="1.0" Value="{Binding Volume, Mode=TwoWay}" Width="150" HorizontalAlignment="Left" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                            <TextBlock Text="Mute:" VerticalAlignment="Center" Margin="0,0,6,0" />
-                            <CheckBox x:Name="PART_MuteCheckbox" IsChecked="{Binding Muted, Mode=TwoWay}" VerticalAlignment="Center" />
-                        </StackPanel>
                     </StackPanel>
 
                 </StackPanel>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -128,30 +128,42 @@ namespace ProjectionMapper
             _vm.DeleteImportedRequested += async imported => await HandleDeleteImportedAsync(imported);
 
             // Wire playback controls to VideoService
-            _vm.PlayPauseRequested += async () =>
-            {
+            _vm.PlayPauseRequestedAsync += async () =>
+                  {
                 try
-                {
-                    // Toggle playback: after VM toggles IsPlaying, run the desired state
+            {
+                 // Toggle playback: after VM toggles IsPlaying, run the desired state
                     if (_vm.IsPlaying)
-                    {
-                        await _videoService.ResumeAllAsync();
-                    }
-                    else
-                    {
-                        await _videoService.PauseAllAsync();
-                    }
+       {
+       Debug.WriteLine("VideoService: Resuming all layers");
+            await _videoService.ResumeAllAsync();
+ Debug.WriteLine("VideoService: Resume completed");
+      }
+ else
+             {
+       Debug.WriteLine("VideoService: Pausing all layers");
+     await _videoService.PauseAllAsync();
+              Debug.WriteLine("VideoService: Pause completed");
+     }
+     }
+          catch (Exception ex)
+{
+  Debug.WriteLine($"VideoService: PlayPause operation failed: {ex}");
                 }
-                catch { }
-            };
+          };
 
-            _vm.RestartRequested += async () =>
-            {
-                try
-                {
-                    await _videoService.RestartAllAsync();
-                }
-                catch { }
+     _vm.RestartRequestedAsync += async () =>
+     {
+    try
+  {
+  Debug.WriteLine("VideoService: Restarting all layers");
+   await _videoService.RestartAllAsync();
+  Debug.WriteLine("VideoService: Restart completed");
+ }
+        catch (Exception ex)
+             {
+          Debug.WriteLine($"VideoService: Restart operation failed: {ex}");
+   }
             };
 
             // populate monitor list for UI using Win32 EnumDisplayMonitors and store monitor info
@@ -276,79 +288,40 @@ namespace ProjectionMapper
                     PART_PlayAudioCheckbox.Unchecked += PlayAudioCheckbox_CheckedChanged;
                 }
 
-                // Wire volume slider
-                if (PART_VolumeSlider != null)
-                {
-                    PART_VolumeSlider.ValueChanged += VolumeSlider_ValueChanged;
-                }
-
-                // Wire mute checkbox
-                if (PART_MuteCheckbox != null)
-                {
-                    PART_MuteCheckbox.Checked += MuteCheckbox_CheckedChanged;
-                    PART_MuteCheckbox.Unchecked += MuteCheckbox_CheckedChanged;
-                }
+                // Volume slider removed - volume is now fixed at 100%
+      // Mute checkbox removed - audio is off by default until "Play Audio" is checked
             }
-            catch { }
+     catch { }
         }
 
         private void PlayAudioCheckbox_CheckedChanged(object sender, RoutedEventArgs e)
         {
-            try
-            {
-                var imported = _vm.SelectedImportedVideo;
-                if (imported?.HostLayer == null) return;
+try
+{
+          var imported = _vm.SelectedImportedVideo;
+  if (imported?.HostLayer == null) return;
 
-                var playAudio = imported.PlayAudio; // This reads from the bound property
+        var playAudio = imported.PlayAudio; // This reads from the bound property
 
-                if (playAudio)
-                {
-                    // Start audio for host layer without re-registering the decoder (prevents duplicate decoders)
-                    if (!string.IsNullOrEmpty(imported.HostLayer.Id))
-                    {
-                        _videoService.StartAudioForLayer(imported.HostLayer.Id);
-                    }
-                }
-                else
-                {
-                    // Stop audio for host layer
-                    if (!string.IsNullOrEmpty(imported.HostLayer.Id))
-                    {
-                        _videoService.StopAudioForLayer(imported.HostLayer.Id);
-                    }
-                }
-            }
-            catch { }
+       if (playAudio)
+     {
+        // Start audio for host layer without re-registering the decoder (prevents duplicate decoders)
+         if (!string.IsNullOrEmpty(imported.HostLayer.Id))
+       {
+      _videoService.StartAudioForLayer(imported.HostLayer.Id);
+         }
+     }
+    else
+      {
+       // Stop audio for host layer
+      if (!string.IsNullOrEmpty(imported.HostLayer.Id))
+     {
+     _videoService.StopAudioForLayer(imported.HostLayer.Id);
+           }
         }
-
-        private void VolumeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
-        {
-            try
-            {
-                var imported = _vm.SelectedImportedVideo;
-                if (imported?.HostLayer != null && !string.IsNullOrEmpty(imported.HostLayer.Id))
-                {
-                    // The binding will update the model property, but also update the audio service
-                    _videoService.SetLayerVolume(imported.HostLayer.Id, (float)e.NewValue);
-                }
-            }
-            catch { }
-        }
-
-        private void MuteCheckbox_CheckedChanged(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                var imported = _vm.SelectedImportedVideo;
-                if (imported?.HostLayer != null && !string.IsNullOrEmpty(imported.HostLayer.Id))
-                {
-                    // The binding will update the model property, but also update the audio service
-                    var muted = imported.Muted; // This reads from the bound property
-                    _videoService.SetLayerMute(imported.HostLayer.Id, muted);
-                }
-            }
-            catch { }
-        }
+  }
+      catch { }
+  }
 
         private void PART_MeshMonitorCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
@@ -464,6 +437,7 @@ namespace ProjectionMapper
                 // Create or show fullscreen window on the selected monitor
                 if (item.Index >= 0 && item.Index < _monitors.Count)
                 {
+                    _rendererManager.HideFullScreenWindow(item.Index);
                     CreateOrShowFullScreenForMonitor(item.Index);
                 }
                 else


### PR DESCRIPTION
• Add loop-aware position tracking and probe video duration (ffprobe) so pause/resume uses loop-relative timestamps • Remove use of -stream_loop and handle looping by restarting the ffmpeg session; clamp/resume seek positions to duration • Clear audio buffer on session start and when toggling audio to eliminate loop/restart artifacts • Simplify EOF handling: return/exit on EOF in video/audio readers so outer loop can restart cleanly • Make stderr reader null-safe and improve audio auto-start logic when buffer fills • Improve process cleanup and cancellation handling to avoid race conditions during pause/resume/restart