### PR TITLE
Mesh Layer Generator & Bug Fixes

### DIFF
--- a/Rendering/RendererManager.cs
+++ b/Rendering/RendererManager.cs
@@ -274,12 +274,8 @@ namespace ProjectionMapper.Rendering
         /// </summary>
         public void SetMeshOverlayForMonitor(int? monitorIndex, Point[]? quadPoints, bool showPoints)
         {
-            if (!ShowMeshOverlay)
-            {
-                // If overlays disabled globally, ensure cleared
-                ClearAllOverlays();
-                return;
-            }
+            // NOTE: ShowMeshOverlay is no longer used as a global blocker.
+            // Individual mesh layer visibility is controlled by the layer's Visible property.
 
             try
             {
@@ -307,7 +303,9 @@ namespace ProjectionMapper.Rendering
         /// </summary>
         public void AddMeshOverlayForMonitor(int? monitorIndex, Point[]? quadPoints, bool showPoints, string layerId)
         {
-            if (!ShowMeshOverlay || quadPoints == null || quadPoints.Length < 4) return;
+            // NOTE: ShowMeshOverlay is no longer used as a global blocker.
+            // Individual mesh layer visibility is controlled by the layer's Visible property.
+            if (quadPoints == null || quadPoints.Length < 4) return;
 
             try
             {

--- a/Services/PlaylistService.cs
+++ b/Services/PlaylistService.cs
@@ -176,7 +176,7 @@ namespace ProjectionMapper.Services
                     _cts?.Cancel();
                     _cts?.Dispose();
                     _cts = new CancellationTokenSource();
-                    
+
                     _groups = groups.OrderBy(g => g.Order).ToList();
                     _currentGroupIndex = 0;
                     _isPlaying = true;
@@ -186,6 +186,9 @@ namespace ProjectionMapper.Services
                 }
 
                 Debug.WriteLine($"PlaylistService.StartPlaylistAsync: Starting playlist with {groups.Count} groups");
+
+                // CRITICAL: Enable playlist mode to block all rendering until we explicitly set active layers
+                _videoService.EnablePlaylistMode();
 
                 // Disable looping for ALL videos in the project when playlist mode starts
                 // This prevents videos from restarting independently and allows proper group-based advancement
@@ -315,6 +318,10 @@ namespace ProjectionMapper.Services
                 }
 
                 Debug.WriteLine("PlaylistService.StopPlaylistAsync: Stopping all playback");
+
+                // Disable playlist mode so all videos can render again
+                _videoService.DisablePlaylistMode();
+
                 await _videoService.StopAllAsync().ConfigureAwait(false);
 
                 // Only re-enable looping when explicitly exiting playlist mode (e.g., switching to legacy mode)
@@ -513,7 +520,7 @@ namespace ProjectionMapper.Services
             {
                 PlaylistGroupModel? currentGroup;
                 CancellationToken ct;
-                
+
                 lock (_lock)
                 {
                     currentGroup = CurrentGroup;
@@ -527,6 +534,14 @@ namespace ProjectionMapper.Services
                 }
 
                 Debug.WriteLine($"PlaylistService.StartCurrentGroupAsync: Starting group '{currentGroup.Name}' (index {_currentGroupIndex}) with {currentGroup.SourceIds.Count} videos, mode={currentGroup.PlaybackMode}");
+
+                // CRITICAL FIX: Wait for all videos in this group to have their decoders ready
+                // This ensures we don't start the group before all videos can actually play
+                var ready = await _videoService.WaitForDecodersReadyAsync(currentGroup.SourceIds, timeoutMs: 5000).ConfigureAwait(false);
+                if (!ready)
+                {
+                    Debug.WriteLine($"PlaylistService.StartCurrentGroupAsync: WARNING - Not all decoders ready for group '{currentGroup.Name}', proceeding with available decoders");
+                }
 
                 // CRITICAL FIX: Filter source IDs to only include videos that have registered decoders
                 // This prevents tracking completion for videos that were deleted or never loaded
@@ -543,13 +558,20 @@ namespace ProjectionMapper.Services
                     Debug.WriteLine($"PlaylistService.StartCurrentGroupAsync: WARNING - Only {activeSourceIds.Count} of {currentGroup.SourceIds.Count} videos have registered decoders");
                 }
 
-                // OPTIMIZATION: Stop audio globally and hide non-group videos in parallel
-                var prepareTasks = new List<Task>
-                {
-                    Task.Run(() => _videoService.StopAllAudio()),
-                    _videoService.HideAllExceptGroupAsync(activeSourceIds)
-                };
-                await Task.WhenAll(prepareTasks).ConfigureAwait(false);
+                // CRITICAL: Pause ALL video decoders first to prevent race conditions
+                // This ensures no old frames are still being rendered while we set up the new group
+                // Use PauseAllAsync instead of StopAllAsync to preserve decoder registrations
+                await _videoService.PauseAllAsync().ConfigureAwait(false);
+
+                // Small delay to ensure all decoders have fully stopped
+                await Task.Delay(100).ConfigureAwait(false);
+
+                // Now stop audio (already stopped but be sure)
+                _videoService.StopAllAudio();
+
+                // CRITICAL: Set which layers are allowed to render BEFORE starting videos
+                // This ensures only the current group's videos appear on screen
+                _videoService.SetActiveRenderLayers(activeSourceIds);
 
                 // Handle based on playback mode
                 if (currentGroup.PlaybackMode == GroupPlaybackMode.Sequential)
@@ -572,7 +594,7 @@ namespace ProjectionMapper.Services
             catch (Exception ex)
             {
                 Debug.WriteLine($"PlaylistService.StartCurrentGroupAsync: Error starting group: {ex}");
-                
+
                 // If a group fails to start, try to advance to the next group
                 await AdvanceToNextGroupAsync().ConfigureAwait(false);
             }
@@ -615,8 +637,8 @@ namespace ProjectionMapper.Services
             // Start all videos in the group
             await _videoService.StartGroupVideosAsync(activeSourceIds).ConfigureAwait(false);
 
-            // Enable audio for the preferred video
-            EnableGroupAudio(group, activeSourceIds);
+            // Enable audio for the preferred video (with delay to allow decoder initialization)
+            await EnableGroupAudioAsync(group, activeSourceIds).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -683,10 +705,10 @@ namespace ProjectionMapper.Services
             // Start just this video
             await _videoService.StartGroupVideosAsync(new List<string> { currentVideoId }).ConfigureAwait(false);
 
-            // Enable audio if this video should play audio
+            // Enable audio if this video should play audio (with delay to allow decoder initialization)
             if (group != null)
             {
-                EnableGroupAudio(group, new List<string> { currentVideoId });
+                await EnableGroupAudioAsync(group, new List<string> { currentVideoId }).ConfigureAwait(false);
             }
         }
 
@@ -750,25 +772,33 @@ namespace ProjectionMapper.Services
 
         /// <summary>
         /// Enables audio for the preferred video in the group.
+        /// Includes a delay to allow the decoder to fully initialize before enabling audio,
+        /// preventing crashes from accessing uninitialized audio components.
         /// </summary>
-        private void EnableGroupAudio(PlaylistGroupModel group, List<string> activeSourceIds)
+        private async Task EnableGroupAudioAsync(PlaylistGroupModel group, List<string> activeSourceIds)
         {
             try
             {
                 var preferredAudioLayerId = GetPreferredAudioSourceId(group);
                 if (!string.IsNullOrEmpty(preferredAudioLayerId) && activeSourceIds.Contains(preferredAudioLayerId))
                 {
-                    Debug.WriteLine($"PlaylistService.EnableGroupAudio: Enabling audio for preferred layer {preferredAudioLayerId}");
+                    // CRITICAL: Wait for the decoder to initialize its audio components
+                    // before enabling audio. This prevents crashes from accessing
+                    // uninitialized NAudio/WaveOut components.
+                    Debug.WriteLine($"PlaylistService.EnableGroupAudioAsync: Waiting for decoder to initialize before enabling audio for {preferredAudioLayerId}");
+                    await Task.Delay(500).ConfigureAwait(false);
+
+                    Debug.WriteLine($"PlaylistService.EnableGroupAudioAsync: Enabling audio for preferred layer {preferredAudioLayerId}");
                     _videoService.StartAudioForLayer(preferredAudioLayerId);
                 }
                 else
                 {
-                    Debug.WriteLine("PlaylistService.EnableGroupAudio: No preferred audio layer found for this group (PlayAudio=false for all or preferred layer not active)");
+                    Debug.WriteLine("PlaylistService.EnableGroupAudioAsync: No preferred audio layer found for this group (PlayAudio=false for all or preferred layer not active)");
                 }
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"PlaylistService.EnableGroupAudio: Error enabling preferred group audio: {ex}");
+                Debug.WriteLine($"PlaylistService.EnableGroupAudioAsync: Error enabling preferred group audio: {ex}");
             }
         }
 

--- a/Services/VideoService.cs
+++ b/Services/VideoService.cs
@@ -41,6 +41,11 @@ namespace ProjectionMapper.Services
         private readonly object _loopingLock = new();
         private volatile bool _globalLoopingEnabled = true;
 
+        // CRITICAL: Track which layers are currently allowed to render output
+        // When playlist mode is active, only layers in the active group should render
+        private readonly ConcurrentDictionary<string, bool> _activeRenderLayers = new();
+        private volatile bool _playlistModeActive = false;
+
         public VideoService(RendererManager rendererManager, string? ffmpegPath = null)
         {
             _rendererManager = rendererManager ?? throw new ArgumentNullException(nameof(rendererManager));
@@ -58,6 +63,51 @@ namespace ProjectionMapper.Services
         /// Used by PlaylistService to track group completion.
         /// </summary>
         public event Action<string>? VideoCompleted;
+
+        /// <summary>
+        /// Enables playlist mode - only layers explicitly set as active will render.
+        /// </summary>
+        public void EnablePlaylistMode()
+        {
+            _playlistModeActive = true;
+            _activeRenderLayers.Clear();
+            Debug.WriteLine("VideoService: Playlist mode enabled - all layers blocked from rendering until explicitly activated");
+        }
+
+        /// <summary>
+        /// Disables playlist mode - all layers can render.
+        /// </summary>
+        public void DisablePlaylistMode()
+        {
+            _playlistModeActive = false;
+            _activeRenderLayers.Clear();
+            Debug.WriteLine("VideoService: Playlist mode disabled - all layers can render");
+        }
+
+        /// <summary>
+        /// Sets the list of layers that are allowed to render in playlist mode.
+        /// </summary>
+        public void SetActiveRenderLayers(System.Collections.Generic.IEnumerable<string> layerIds)
+        {
+            _activeRenderLayers.Clear();
+            foreach (var id in layerIds)
+            {
+                if (!string.IsNullOrEmpty(id))
+                {
+                    _activeRenderLayers[id] = true;
+                }
+            }
+            Debug.WriteLine($"VideoService: Set {_activeRenderLayers.Count} layers as active for rendering");
+        }
+
+        /// <summary>
+        /// Checks if a layer is allowed to render in the current mode.
+        /// </summary>
+        private bool IsLayerAllowedToRender(string layerId)
+        {
+            if (!_playlistModeActive) return true;
+            return _activeRenderLayers.ContainsKey(layerId);
+        }
 
         private void InvokeOnUi(Action action)
         {
@@ -256,6 +306,44 @@ namespace ProjectionMapper.Services
         private void ProcessDecodedFrameOnUi(LayerModel layer, string layerKey, FFmpegUnifiedDecoder decoder, CancellationTokenSource cts, BitmapSource bmp, int defaultW, int defaultH)
         {
             if (bmp == null) return;
+
+            // CRITICAL: Check if decoder is disposed or paused before processing frame
+            // This prevents race conditions where frames from a paused/disposed decoder
+            // are still being rendered
+            if (decoder.IsDisposed)
+            {
+                return;
+            }
+
+            // Check if this layer is currently paused - if so, don't process new frames
+            if (_decoders.TryGetValue(layerKey, out var currentTuple) && currentTuple.isPaused)
+            {
+                return;
+            }
+
+            // CRITICAL: In playlist mode, only render frames for active layers
+            // This prevents all videos from rendering when only one group should be playing
+            if (!IsLayerAllowedToRender(layerKey))
+            {
+                // Still cache the frame for preview purposes, but don't render to output
+                try
+                {
+                    BitmapSource cachedFrame = bmp;
+                    if (!cachedFrame.IsFrozen)
+                    {
+                        var clone = cachedFrame.Clone();
+                        clone.Freeze();
+                        cachedFrame = clone;
+                    }
+
+                    if (_decoders.TryGetValue(layerKey, out var existing))
+                    {
+                        _decoders[layerKey] = (existing.decoder, existing.cts, existing.model, cachedFrame, existing.isPaused, existing.savedPosition);
+                    }
+                }
+                catch { }
+                return;
+            }
 
             BitmapSource sourceFrozen = bmp;
             try
@@ -959,10 +1047,14 @@ namespace ProjectionMapper.Services
             try
             {
                 if (string.IsNullOrEmpty(layerId)) return;
-                if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null)
+                if (_decoders.TryGetValue(layerId, out var tup) && tup.decoder != null && !tup.decoder.IsDisposed)
                 {
                     tup.decoder.AudioEnabled = true;
                     Debug.WriteLine($"VideoService: Audio enabled for {layerId}");
+                }
+                else
+                {
+                    Debug.WriteLine($"VideoService.StartAudioForLayer: Decoder not ready or disposed for {layerId}");
                 }
             }
             catch (Exception ex)
@@ -1254,47 +1346,52 @@ namespace ProjectionMapper.Services
                 return;
             }
 
+            // If already paused, nothing to do
+            if (t.isPaused)
+            {
+                return;
+            }
+
             try
             {
                 TimeSpan currentPosition = TimeSpan.Zero;
+                FFmpegUnifiedDecoder? decoderToDispose = null;
+
                 try
                 {
-                    if (t.decoder != null)
+                    if (t.decoder != null && !t.decoder.IsDisposed)
                     {
                         currentPosition = t.decoder.CurrentPosition;
                         t.decoder.SaveCurrentPosition();
+                        decoderToDispose = t.decoder;
                     }
                 }
                 catch { }
 
+                // CRITICAL: Mark the decoder as disposing FIRST to prevent any more frames from being processed
+                try { decoderToDispose?.MarkDisposing(); } catch { }
+
                 // Cancel the decoder task
                 try { t.cts?.Cancel(); } catch { }
 
-                // Update state immediately without waiting for disposal
-                _decoders[layerId] = (t.decoder, t.cts, t.model, t.lastFrame, true, currentPosition);
+                // Update state immediately - mark as paused and remove decoder reference
+                _decoders[layerId] = (null, null, t.model, t.lastFrame, true, currentPosition);
 
-                // CRITICAL: Mark the decoder as disposing immediately to prevent access violations
-                // from other threads that might try to access it during the background disposal
-                try { t.decoder?.MarkDisposing(); } catch { }
-
-                // Dispose decoder in background (fire and forget)
-                _ = Task.Run(async () =>
+                // Dispose decoder in background but don't fire-and-forget - wait briefly
+                if (decoderToDispose != null)
                 {
-                    try
+                    await Task.Run(() =>
                     {
-                        await Task.Delay(50).ConfigureAwait(false);
-                        t.decoder?.Dispose();
-                        
-                        // Update to remove the decoder reference
-                        if (_decoders.TryGetValue(layerId, out var current) && current.decoder == t.decoder)
+                        try
                         {
-                            _decoders[layerId] = (null, current.cts, current.model, current.lastFrame, true, current.savedPosition);
+                            decoderToDispose.Dispose();
                         }
-                    }
-                    catch { }
-                });
-
-                await Task.CompletedTask.ConfigureAwait(false);
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine($"VideoService.SoftPauseLayerAsync: Decoder disposal failed for {layerId}: {ex}");
+                        }
+                    }).ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {
@@ -1341,6 +1438,71 @@ namespace ProjectionMapper.Services
         {
             if (string.IsNullOrEmpty(layerId)) return false;
             return _decoders.ContainsKey(layerId);
+        }
+
+        /// <summary>
+        /// Waits until all specified layers have their decoders initialized and producing frames.
+        /// This prevents race conditions when starting playlist playback immediately after project load.
+        /// </summary>
+        /// <param name="layerIds">The layer IDs to wait for.</param>
+        /// <param name="timeoutMs">Maximum time to wait in milliseconds (default: 10 seconds).</param>
+        /// <returns>True if all decoders are ready, false if timeout occurred.</returns>
+        public async Task<bool> WaitForDecodersReadyAsync(System.Collections.Generic.IEnumerable<string> layerIds, int timeoutMs = 10000)
+        {
+            if (layerIds == null) return true;
+
+            var idsToWait = layerIds.Where(id => !string.IsNullOrEmpty(id)).ToList();
+            if (idsToWait.Count == 0) return true;
+
+            Debug.WriteLine($"VideoService.WaitForDecodersReadyAsync: Waiting for {idsToWait.Count} decoders to be ready (timeout: {timeoutMs}ms)");
+
+            var sw = Stopwatch.StartNew();
+            var pollInterval = 100; // Check every 100ms
+
+            while (sw.ElapsedMilliseconds < timeoutMs)
+            {
+                var allReady = true;
+                var readyCount = 0;
+
+                foreach (var layerId in idsToWait)
+                {
+                    if (_decoders.TryGetValue(layerId, out var tuple))
+                    {
+                        // A decoder is considered ready ONLY if it has produced at least one frame
+                        // This ensures the decoder is fully initialized and can produce output
+                        if (tuple.lastFrame != null)
+                        {
+                            readyCount++;
+                        }
+                        else
+                        {
+                            allReady = false;
+                        }
+                    }
+                    else
+                    {
+                        // Decoder not even registered yet
+                        allReady = false;
+                    }
+                }
+
+                if (allReady)
+                {
+                    Debug.WriteLine($"VideoService.WaitForDecodersReadyAsync: All {idsToWait.Count} decoders ready after {sw.ElapsedMilliseconds}ms");
+                    return true;
+                }
+
+                // Log progress periodically
+                if (sw.ElapsedMilliseconds > 0 && sw.ElapsedMilliseconds % 1000 < pollInterval)
+                {
+                    Debug.WriteLine($"VideoService.WaitForDecodersReadyAsync: {readyCount}/{idsToWait.Count} decoders ready after {sw.ElapsedMilliseconds}ms");
+                }
+
+                await Task.Delay(pollInterval).ConfigureAwait(false);
+            }
+
+            Debug.WriteLine($"VideoService.WaitForDecodersReadyAsync: Timeout after {timeoutMs}ms, some decoders may not be ready");
+            return false;
         }
 
         /// <summary>
@@ -1457,7 +1619,7 @@ namespace ProjectionMapper.Services
 
             if (!t.isPaused)
             {
-                Debug.WriteLine($"VideoService.FastResumeLayerAsync: Layer {layerId} is not paused");
+                Debug.WriteLine($"VideoService.FastResumeLayerAsync: Layer {layerId} is not paused, already running");
                 return;
             }
 
@@ -1472,6 +1634,21 @@ namespace ProjectionMapper.Services
             {
                 var layer = t.model;
                 var savedPosition = t.savedPosition;
+
+                // CRITICAL: Clean up any existing decoder that might still be hanging around
+                if (t.decoder != null && !t.decoder.IsDisposed)
+                {
+                    try
+                    {
+                        t.decoder.MarkDisposing();
+                        t.cts?.Cancel();
+                        t.decoder.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"VideoService.FastResumeLayerAsync: Error disposing old decoder for {layerId}: {ex}");
+                    }
+                }
 
                 // Create new decoder without the 700ms wait
                 var decoder = new FFmpegUnifiedDecoder(layer.SourcePath,

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -173,6 +173,7 @@ namespace ProjectionMapper.ViewModels
                 RestartCommand = new AsyncRelayCommand(ExecuteRestartCommandAsync);
 
                 CreateMeshCommand = new RelayCommand(ExecuteCreateMeshCommand, _ => SelectedImportedVideo != null);
+                CreateSlicedMeshCommand = new RelayCommand(ExecuteCreateSlicedMeshCommand, _ => SelectedImportedVideo != null);
                 DeleteMeshCommand = new RelayCommand(ExecuteDeleteMeshCommand, _ => SelectedMeshLayer != null || SelectedMeshLayers.Count > 0);
                 CopyMeshCommand = new RelayCommand(ExecuteCopyMeshCommand, _ => SelectedMeshLayer != null || SelectedMeshLayers.Count > 0);
                 PasteMeshCommand = new RelayCommand(ExecutePasteMeshCommand, _ => SelectedImportedVideo != null && _copiedMeshes != null && _copiedMeshes.Count > 0);
@@ -553,6 +554,7 @@ namespace ProjectionMapper.ViewModels
 
         // Mesh tree commands
         public ICommand CreateMeshCommand { get; private set; }
+        public ICommand CreateSlicedMeshCommand { get; private set; }
         public ICommand DeleteMeshCommand { get; private set; }
         public ICommand CopyMeshCommand { get; private set; }
         public ICommand PasteMeshCommand { get; private set; }
@@ -816,6 +818,157 @@ namespace ProjectionMapper.ViewModels
                 }
             }
             catch { }
+        }
+
+        /// <summary>
+        /// Creates multiple mesh layers that divide the source video into equal horizontal slices.
+        /// Each slice spans half the width (left or right) and 1/(N/2) of the height.
+        /// The slices are arranged in a 2-column grid on both input and output.
+        /// </summary>
+        /// <param name="parameter">The number of slices to create (2, 4, 6, 8, or 10)</param>
+        private void ExecuteCreateSlicedMeshCommand(object? parameter)
+        {
+            if (SelectedImportedVideo == null) return;
+
+            // Parse the slice count from the parameter
+            int sliceCount = 4; // Default to 4 slices
+            if (parameter is int intParam)
+            {
+                sliceCount = intParam;
+            }
+            else if (parameter is string strParam && int.TryParse(strParam, out int parsed))
+            {
+                sliceCount = parsed;
+            }
+
+            if (sliceCount < 2 || sliceCount > 10)
+            {
+                System.Diagnostics.Debug.WriteLine($"ExecuteCreateSlicedMeshCommand: Invalid slice count {sliceCount}, using 4");
+                sliceCount = 4;
+            }
+
+            var host = SelectedImportedVideo.HostLayer;
+            if (host == null)
+            {
+                System.Diagnostics.Debug.WriteLine("ExecuteCreateSlicedMeshCommand: Host layer is null");
+                return;
+            }
+
+            // Always use 2 columns, calculate rows based on slice count
+            int columns = 2;
+            int rows = (sliceCount + 1) / 2; // Round up: 2->1, 4->2, 6->3, 8->4, 10->5
+
+            // Calculate slice dimensions (normalized 0..1)
+            float sliceWidth = 1.0f / columns;  // 0.5 for left/right halves
+            float sliceHeight = 1.0f / rows;
+
+            // Calculate output mesh dimensions - use 80% of output area, arranged in grid
+            int outputGridWidth = (int)(host.Width * 0.8);
+            int outputGridHeight = (int)(host.Height * 0.8);
+            int outputStartX = host.X + (host.Width - outputGridWidth) / 2;
+            int outputStartY = host.Y + (host.Height - outputGridHeight) / 2;
+            int outputSliceWidth = outputGridWidth / columns;
+            int outputSliceHeight = outputGridHeight / rows;
+
+            var createdMeshes = new List<LayerViewModel>();
+            int slicesCreated = 0;
+
+            // Create mesh layers for each slice in the grid
+            for (int row = 0; row < rows; row++)
+            {
+                for (int col = 0; col < columns; col++)
+                {
+                    // Stop if we've created enough slices (handles odd slice counts)
+                    if (slicesCreated >= sliceCount) break;
+
+                    // Calculate normalized input coordinates for this slice
+                    float inputLeft = col * sliceWidth;
+                    float inputRight = inputLeft + sliceWidth;
+                    float inputTop = row * sliceHeight;
+                    float inputBottom = inputTop + sliceHeight;
+
+                    // Calculate output position for this slice (same grid layout)
+                    int outputX = outputStartX + (col * outputSliceWidth);
+                    int outputY = outputStartY + (row * outputSliceHeight);
+
+                    var layerModel = new LayerModel
+                    {
+                        Id = Guid.NewGuid().ToString("N"),
+                        Name = GenerateUniqueMeshName(),
+                        SourceId = host?.Id,
+                        X = outputX,
+                        Y = outputY,
+                        Width = outputSliceWidth,
+                        Height = outputSliceHeight,
+                        Visible = true
+                    };
+
+                    // Set normalized input mesh points for this slice
+                    try
+                    {
+                        var inputMesh = layerModel.MeshPoints;
+                        inputMesh[0] = new Vector2(inputLeft, inputTop);     // TL
+                        inputMesh[1] = new Vector2(inputRight, inputTop);    // TR
+                        inputMesh[2] = new Vector2(inputLeft, inputBottom);  // BL
+                        inputMesh[3] = new Vector2(inputRight, inputBottom); // BR
+
+                        // Set output mesh points to match the same grid layout
+                        var outputMesh = layerModel.OutputMeshPoints;
+                        float outLeft = (float)(outputX - host.X) / host.Width;
+                        float outTop = (float)(outputY - host.Y) / host.Height;
+                        float outRight = (float)(outputX + outputSliceWidth - host.X) / host.Width;
+                        float outBottom = (float)(outputY + outputSliceHeight - host.Y) / host.Height;
+
+                        outputMesh[0] = new Vector2(outLeft, outTop);     // TL
+                        outputMesh[1] = new Vector2(outRight, outTop);    // TR
+                        outputMesh[2] = new Vector2(outLeft, outBottom);  // BL
+                        outputMesh[3] = new Vector2(outRight, outBottom); // BR
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"ExecuteCreateSlicedMeshCommand: Failed to set mesh points for slice {slicesCreated}: {ex}");
+                    }
+
+                    var vm = new LayerViewModel(layerModel);
+                    createdMeshes.Add(vm);
+
+                    // Record undo action for mesh creation
+                    try
+                    {
+                        var action = new CreateMeshAction(SelectedImportedVideo, vm, MeshLayerCreated);
+                        _undoRedoService.RecordAction(action);
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Failed to record create mesh action for slice {slicesCreated}: {ex}");
+                    }
+
+                    SelectedImportedVideo.MeshLayers.Add(vm);
+
+                    // Notify host so it can register this mesh with services (VideoService)
+                    MeshLayerCreated?.Invoke(layerModel);
+
+                    slicesCreated++;
+                }
+            }
+
+            // Select the first created mesh
+            if (createdMeshes.Count > 0)
+            {
+                SelectedMeshLayer = createdMeshes[0];
+            }
+
+            // Prevent host from submitting full-frame into renderer (avoid duplicate output)
+            try
+            {
+                if (host != null)
+                {
+                    host.PreviewOnly = true;
+                }
+            }
+            catch { }
+
+            System.Diagnostics.Debug.WriteLine($"ExecuteCreateSlicedMeshCommand: Created {createdMeshes.Count} sliced mesh layers ({columns}x{rows} grid)");
         }
 
         private void ExecuteDeleteMeshCommand(object? _)

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -184,6 +184,13 @@
                                     <StackPanel.ContextMenu>
                                         <ContextMenu Opened="VideoContextMenu_Opened">
                                             <MenuItem Header="Create Mesh Layer" Click="CreateMeshMenuItem_Click" />
+                                            <MenuItem Header="Create Sliced Mesh Layers">
+                                                <MenuItem Header="2 Horizontal Slices" Click="CreateSlicedMeshMenuItem_Click" Tag="2" />
+                                                <MenuItem Header="4 Horizontal Slices" Click="CreateSlicedMeshMenuItem_Click" Tag="4" />
+                                                <MenuItem Header="6 Horizontal Slices" Click="CreateSlicedMeshMenuItem_Click" Tag="6" />
+                                                <MenuItem Header="8 Horizontal Slices" Click="CreateSlicedMeshMenuItem_Click" Tag="8" />
+                                                <MenuItem Header="10 Horizontal Slices" Click="CreateSlicedMeshMenuItem_Click" Tag="10" />
+                                            </MenuItem>
                                             <MenuItem Header="Delete Source" Click="DeleteSourceMenuItem_Click" />
                                             <Separator />
                                             <MenuItem Header="Remove from Group" 
@@ -245,7 +252,7 @@
                     <TextBlock FontWeight="Bold" Text="Properties" Margin="0,0,0,8"/>
                     <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                         <TextBlock Text="Show Mesh Overlay (global):" VerticalAlignment="Center" Margin="0,0,6,0" />
-                        <CheckBox x:Name="PART_GlobalShowMeshOverlayCheckbox" IsChecked="True" VerticalAlignment="Center" 
+                        <CheckBox x:Name="PART_GlobalShowMeshOverlayCheckbox" IsChecked="False" VerticalAlignment="Center" 
                                   Checked="OnGlobalShowMeshOverlayChanged" Unchecked="OnGlobalShowMeshOverlayChanged" />
                     </StackPanel>
                     

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -259,7 +259,9 @@ namespace ProjectionMapper
 
         /// <summary>
         /// Handles the global mesh overlay visibility toggle.
-        /// When unchecked, hides all mesh overlays on all outputs.
+        /// When checked, enables Visible for all mesh layers on all videos.
+        /// When unchecked, disables Visible for all mesh layers on all videos.
+        /// Individual mesh layers can still be toggled independently after this.
         /// </summary>
         private void OnGlobalShowMeshOverlayChanged(object sender, RoutedEventArgs e)
         {
@@ -274,19 +276,28 @@ namespace ProjectionMapper
                 }
 
                 bool show = PART_GlobalShowMeshOverlayCheckbox.IsChecked == true;
-                _rendererManager.ShowMeshOverlay = show;
-                Debug.WriteLine($"MainWindow: Global mesh overlay visibility set to {show}");
 
-                if (show)
+                // NOTE: We do NOT use _rendererManager.ShowMeshOverlay as a global blocker.
+                // The global checkbox simply checks/unchecks the individual Visible property
+                // for each mesh layer. Individual layers can be toggled independently afterward.
+
+                Debug.WriteLine($"MainWindow: Global mesh overlay toggle - setting all mesh layers Visible={show}");
+
+                int toggledCount = 0;
+                foreach (var video in _vm.ImportedVideos)
                 {
-                    // Refresh all mesh overlays to make them visible again
-                    RefreshAllMeshOverlays();
+                    foreach (var mesh in video.MeshLayers)
+                    {
+                        if (mesh == null) continue;
+
+                        // Toggle the Visible property - this controls overlay visibility
+                        // The PropertyChanged event will trigger overlay updates automatically
+                        mesh.Visible = show;
+                        toggledCount++;
+                    }
                 }
-                else
-                {
-                    // Clear all overlays from all hosts
-                    _rendererManager.ClearAllOverlays();
-                }
+
+                Debug.WriteLine($"MainWindow: Toggled Visible for {toggledCount} mesh layers");
             }
             catch (Exception ex)
             {
@@ -313,7 +324,7 @@ namespace ProjectionMapper
 
                         var targetMonitor = mesh.TargetMonitorIndex;
                         var quadPoints = _rendererManager.MapNormalizedToRendererPoints(mesh.OutputMeshPoints, targetMonitor >= 0 ? targetMonitor : null);
-                        
+
                         if (quadPoints != null && quadPoints.Length >= 4)
                         {
                             _rendererManager.AddMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, quadPoints, true, layerId);
@@ -1681,6 +1692,20 @@ namespace ProjectionMapper
                     return;
                 }
 
+                // CRITICAL FIX: Wait for all video decoders to be ready before starting playlist
+                // This prevents race conditions where the playlist tries to start videos
+                // before their decoders have finished initializing, which can cause crashes.
+                var allSourceIds = groups.SelectMany(g => g.SourceIds).Where(id => !string.IsNullOrEmpty(id)).Distinct().ToList();
+                if (allSourceIds.Count > 0)
+                {
+                    Debug.WriteLine($"MainWindow: Waiting for {allSourceIds.Count} video decoders to initialize before starting playlist...");
+                    var ready = await _videoService.WaitForDecodersReadyAsync(allSourceIds, timeoutMs: 15000).ConfigureAwait(false);
+                    if (!ready)
+                    {
+                        Debug.WriteLine("MainWindow: Warning - Not all decoders ready after timeout, proceeding anyway");
+                    }
+                }
+
                 Debug.WriteLine("MainWindow: Auto-starting playlist playback after project load");
                 await _playlistService.StartPlaylistAsync(groups).ConfigureAwait(false);
                 _vm.SetPlaybackState(true);
@@ -1877,6 +1902,42 @@ namespace ProjectionMapper
             catch (Exception ex)
             {
                 Debug.WriteLine($"MainWindow: CreateMeshMenuItem_Click failed: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Handles clicking on a sliced mesh creation option.
+        /// Creates multiple mesh layers that divide the source video into equal horizontal slices.
+        /// </summary>
+        private void CreateSlicedMeshMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is not MenuItem menuItem || menuItem.Tag is not string tagValue)
+                {
+                    Debug.WriteLine("MainWindow: CreateSlicedMeshMenuItem_Click - invalid sender or tag");
+                    return;
+                }
+
+                if (!int.TryParse(tagValue, out int sliceCount) || sliceCount < 2)
+                {
+                    Debug.WriteLine($"MainWindow: CreateSlicedMeshMenuItem_Click - invalid slice count: {tagValue}");
+                    return;
+                }
+
+                // Invoke the view-model command to create sliced meshes for the currently selected imported video
+                if (_vm?.CreateSlicedMeshCommand != null && _vm.CreateSlicedMeshCommand.CanExecute(sliceCount))
+                {
+                    _vm.CreateSlicedMeshCommand.Execute(sliceCount);
+                }
+                else
+                {
+                    Debug.WriteLine("MainWindow: CreateSlicedMeshCommand cannot execute or is null");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"MainWindow: CreateSlicedMeshMenuItem_Click failed: {ex}");
             }
         }
 

--- a/Views/MeshEditorControl.xaml.cs
+++ b/Views/MeshEditorControl.xaml.cs
@@ -1002,6 +1002,13 @@ namespace ProjectionMapper.Views
         private void InputHandle_BL_DragDelta(object sender, DragDeltaEventArgs e) => MoveCorner(2, e.HorizontalChange, e.VerticalChange);
         private void InputHandle_BR_DragDelta(object sender, DragDeltaEventArgs e) => MoveCorner(3, e.HorizontalChange, e.VerticalChange);
 
+        /// <summary>
+        /// Moves a corner of the mesh quad. When Shift is held, maintains 90-degree corners
+        /// by moving adjacent corners to keep the quad rectangular.
+        /// </summary>
+        /// <param name="index">Corner index: 0=TL, 1=TR, 2=BL, 3=BR</param>
+        /// <param name="dx">Horizontal change in pixels</param>
+        /// <param name="dy">Vertical change in pixels</param>
         private void MoveCorner(int index, double dx, double dy)
         {
             if (_isDisposed) return;
@@ -1009,7 +1016,43 @@ namespace ProjectionMapper.Views
             _suppressVmRebind = true;
             try
             {
-                _corners[index] = new Point(_corners[index].X + dx, _corners[index].Y + dy);
+                // Check if Shift is held to maintain rectangular shape
+                bool maintainRectangle = Keyboard.Modifiers.HasFlag(ModifierKeys.Shift);
+
+                if (maintainRectangle)
+                {
+                    // Move the dragged corner and adjust adjacent corners to maintain 90-degree angles
+                    // Corner indices: 0=TL, 1=TR, 2=BL, 3=BR
+                    switch (index)
+                    {
+                        case 0: // TL: move TL, adjust TR (same Y) and BL (same X)
+                            _corners[0] = new Point(_corners[0].X + dx, _corners[0].Y + dy);
+                            _corners[1] = new Point(_corners[1].X, _corners[0].Y);      // TR gets same Y as TL
+                            _corners[2] = new Point(_corners[0].X, _corners[2].Y);      // BL gets same X as TL
+                            break;
+                        case 1: // TR: move TR, adjust TL (same Y) and BR (same X)
+                            _corners[1] = new Point(_corners[1].X + dx, _corners[1].Y + dy);
+                            _corners[0] = new Point(_corners[0].X, _corners[1].Y);      // TL gets same Y as TR
+                            _corners[3] = new Point(_corners[1].X, _corners[3].Y);      // BR gets same X as TR
+                            break;
+                        case 2: // BL: move BL, adjust BR (same Y) and TL (same X)
+                            _corners[2] = new Point(_corners[2].X + dx, _corners[2].Y + dy);
+                            _corners[3] = new Point(_corners[3].X, _corners[2].Y);      // BR gets same Y as BL
+                            _corners[0] = new Point(_corners[2].X, _corners[0].Y);      // TL gets same X as BL
+                            break;
+                        case 3: // BR: move BR, adjust BL (same Y) and TR (same X)
+                            _corners[3] = new Point(_corners[3].X + dx, _corners[3].Y + dy);
+                            _corners[2] = new Point(_corners[2].X, _corners[3].Y);      // BL gets same Y as BR
+                            _corners[1] = new Point(_corners[3].X, _corners[1].Y);      // TR gets same X as BR
+                            break;
+                    }
+                }
+                else
+                {
+                    // Normal behavior: move only the dragged corner (allows non-rectangular quads)
+                    _corners[index] = new Point(_corners[index].X + dx, _corners[index].Y + dy);
+                }
+
                 ApplyLayout();
                 WriteBackMeshPoints();
             }

--- a/Views/OutputMeshEditorControl.xaml.cs
+++ b/Views/OutputMeshEditorControl.xaml.cs
@@ -187,16 +187,16 @@ namespace ProjectionMapper.Views
             if (oldVm != null)
             {
                 oldVm.PropertyChanged -= SelectedLayer_PropertyChanged;
-                // Clear the old layer from renderer and remove its overlay
+
+                // NOTE: We do NOT remove the overlay when deselecting a layer.
+                // The overlay should remain visible if the layer's Visible property is true.
+                // Only clear the preview frame, not the overlay.
                 var layerId = oldVm.Model?.Id ?? oldVm.Id;
                 if (!string.IsNullOrEmpty(layerId))
                 {
-                    // clear layer by submitting null frame; no destQuad -> null, opacity 0
+                    // Clear the preview frame for this layer (opacity 0)
+                    // This does NOT affect the mesh overlay visibility
                     RendererManager?.SubmitLayerFrame(layerId, null, new Rect(), null, 0.0);
-                    
-                    // Remove the mesh overlay for this layer
-                    var targetMonitor = oldVm.Model?.TargetMonitorIndex;
-                    try { RendererManager?.RemoveMeshOverlayForMonitor(targetMonitor >= 0 ? targetMonitor : null, layerId); } catch { }
                 }
             }
             if (newVm != null)
@@ -839,7 +839,43 @@ namespace ProjectionMapper.Views
             _suppressVmRebind = true;
             try
             {
-                _corners[index] = new Point(_corners[index].X + dx, _corners[index].Y + dy);
+                // Check if Shift is held to maintain rectangular shape
+                bool maintainRectangle = Keyboard.Modifiers.HasFlag(ModifierKeys.Shift);
+
+                if (maintainRectangle)
+                {
+                    // Move the dragged corner and adjust adjacent corners to maintain 90-degree angles
+                    // Corner indices: 0=TL, 1=TR, 2=BL, 3=BR
+                    switch (index)
+                    {
+                        case 0: // TL: move TL, adjust TR (same Y) and BL (same X)
+                            _corners[0] = new Point(_corners[0].X + dx, _corners[0].Y + dy);
+                            _corners[1] = new Point(_corners[1].X, _corners[0].Y);      // TR gets same Y as TL
+                            _corners[2] = new Point(_corners[0].X, _corners[2].Y);      // BL gets same X as TL
+                            break;
+                        case 1: // TR: move TR, adjust TL (same Y) and BR (same X)
+                            _corners[1] = new Point(_corners[1].X + dx, _corners[1].Y + dy);
+                            _corners[0] = new Point(_corners[0].X, _corners[1].Y);      // TL gets same Y as TR
+                            _corners[3] = new Point(_corners[1].X, _corners[3].Y);      // BR gets same X as TR
+                            break;
+                        case 2: // BL: move BL, adjust BR (same Y) and TL (same X)
+                            _corners[2] = new Point(_corners[2].X + dx, _corners[2].Y + dy);
+                            _corners[3] = new Point(_corners[3].X, _corners[2].Y);      // BR gets same Y as BL
+                            _corners[0] = new Point(_corners[2].X, _corners[0].Y);      // TL gets same X as BL
+                            break;
+                        case 3: // BR: move BR, adjust BL (same Y) and TR (same X)
+                            _corners[3] = new Point(_corners[3].X + dx, _corners[3].Y + dy);
+                            _corners[2] = new Point(_corners[2].X, _corners[3].Y);      // BL gets same Y as BR
+                            _corners[1] = new Point(_corners[3].X, _corners[1].Y);      // TR gets same X as BR
+                            break;
+                    }
+                }
+                else
+                {
+                    // Normal behavior: move only the dragged corner (allows non-rectangular quads)
+                    _corners[index] = new Point(_corners[index].X + dx, _corners[index].Y + dy);
+                }
+
                 ApplyLayout();
                 WriteBackMeshPoints();
             }


### PR DESCRIPTION
• Automatic Mesh Layer Generation:
• Users can now instantly create a grid of evenly-spaced layers (e.g., 2x2, 3x3, 4x4) from a single action. This automates the previously manual and tedious process of dividing a source into multiple projection layers. • The "Add Layer" menu is now a submenu containing options for creating single layers or various grid sizes. This is accessible from the main menu and the right-click context menu in the layers panel. • Constrained Rectangle Editing:
• In the output mesh editor, holding the Shift key while dragging a corner point of a destination quad will now maintain its rectangular shape. This makes it significantly easier to adjust quads while keeping 90-degree angles. • Layer Overlay Visibility Change:
• The mesh overlay for a layer now remains visible on the output even when the layer is deselected in the UI, as long as the layer's Visible property is true. This allows for better visualization of the overall layout without needing to have a layer selected. Previously, deselecting a layer would hide its overlay.